### PR TITLE
Automated plugin release changes 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
+---
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: monthly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,54 @@
+# Note: additional setup is required, see https://www.jenkins.io/redirect/continuous-delivery-of-plugins
+#
+# Please find additional hints for individual trigger use case
+# configuration options inline this script below.
+#
+---
+name: cd
+on:
+  workflow_dispatch:
+    inputs:
+      validate_only:
+        required: false
+        type: boolean
+        description: |
+          Run validation with release drafter only
+          → Skip the release job
+        # Note: Change this default to true,
+        #       if the checkbox should be checked by default.
+        default: false
+  # If you don't want any automatic trigger in general, then
+  # the following check_run trigger lines should all be commented.
+  # Note: Consider the use case #2 config for 'validate_only' below
+  #       as an alternative option!
+  check_run:
+    types:
+      - completed
+
+permissions:
+  checks: read
+  contents: write
+
+jobs:
+  maven-cd:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
+    with:
+      # Comment / uncomment the validate_only config appropriate to your preference:
+      #
+      # Use case #1 (automatic release):
+      #   - Let any successful Jenkins build trigger another release,
+      #     if there are merged pull requests of interest
+      #   - Perform a validation only run with drafting a release note,
+      #     if manually triggered AND inputs.validate_only has been checked.
+      #
+      validate_only: ${{ inputs.validate_only == true }}
+      #
+      # Alternative use case #2 (no automatic release):
+      #   - Same as use case #1 - but:
+      #     - Let any check_run trigger a validate_only run.
+      #       => enforce the release job to be skipped.
+      #
+      #validate_only: ${{ inputs.validate_only == true || github.event_name == 'check_run' }}
+    secrets:
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -17,13 +17,14 @@ on:
         # Note: Change this default to true,
         #       if the checkbox should be checked by default.
         default: false
+  ###### Opting for manual release trigger so commented check_run trigger
   # If you don't want any automatic trigger in general, then
   # the following check_run trigger lines should all be commented.
   # Note: Consider the use case #2 config for 'validate_only' below
   #       as an alternative option!
-  check_run:
-    types:
-      - completed
+  # check_run:
+  #   types:
+  #     - completed
 
 permissions:
   checks: read
@@ -33,6 +34,7 @@ jobs:
   maven-cd:
     uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
     with:
+      ###### Opting for a manual release trigger so updated validate_only accordingly
       # Comment / uncomment the validate_only config appropriate to your preference:
       #
       # Use case #1 (automatic release):
@@ -41,14 +43,14 @@ jobs:
       #   - Perform a validation only run with drafting a release note,
       #     if manually triggered AND inputs.validate_only has been checked.
       #
-      validate_only: ${{ inputs.validate_only == true }}
+      # validate_only: ${{ inputs.validate_only == true }}
       #
       # Alternative use case #2 (no automatic release):
       #   - Same as use case #1 - but:
       #     - Let any check_run trigger a validate_only run.
       #       => enforce the release job to be skipped.
       #
-      #validate_only: ${{ inputs.validate_only == true || github.event_name == 'check_run' }}
+      validate_only: ${{ inputs.validate_only == true || github.event_name == 'check_run' }}
     secrets:
       MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
       MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.8</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,3 @@
 -Pconsume-incrementals
 -Pmight-produce-incrementals
+-Dchangelist.format=%d.v%s

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>matlab</artifactId>
-	<version>${revision}${changelist}</version>
+	<version>${changelist}</version>
 	<packaging>hpi</packaging>
 
 	<name>MATLAB Plugin</name>
@@ -53,8 +53,7 @@
 	</scm>
 
 	<properties>
-		<revision>2.16.1</revision>
-		<changelist>-SNAPSHOT</changelist>
+		<changelist>999999-SNAPSHOT</changelist>
 		<gitHubRepo>jenkinsci/matlab-plugin</gitHubRepo>
 		<!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
 		<jenkins.baseline>2.387</jenkins.baseline>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>matlab</artifactId>
-	<version> 2.16.1-SNAPSHOT</version>
+	<version>${revision}${changelist}</version>
 	<packaging>hpi</packaging>
 
 	<name>MATLAB Plugin</name>
@@ -46,13 +46,16 @@
 	</pluginRepositories>
 
 	<scm>
-		<connection>scm:git:ssh://github.com/jenkinsci/matlab-plugin.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com/jenkinsci/matlab-plugin.git</developerConnection>
-		<url>https://github.com/jenkinsci/matlab-plugin</url>
-		<tag>HEAD</tag>
+		<connection>scm:git:ssh://github.com/${gitHubRepo}.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/${gitHubRepo}.git</developerConnection>
+		<url>https://github.com/${gitHubRepo}</url>
+		<tag>${scmTag}</tag>
 	</scm>
 
 	<properties>
+		<revision>2.16.1</revision>
+		<changelist>-SNAPSHOT</changelist>
+		<gitHubRepo>jenkinsci/matlab-plugin</gitHubRepo>
 		<!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
 		<jenkins.baseline>2.387</jenkins.baseline>
 		<jenkins.version>${jenkins.baseline}.3</jenkins.version>


### PR DESCRIPTION
This PR consists the changes required to opt for newer Jenkins plugin release process. The documentation for these changes can be found [here](https://www.jenkins.io/doc/developer/publishing/releasing-cd/).

The cd.yaml file is configured to opt for a manual release trigger rather than automated release on every successful build of the default branch.