### PR TITLE
Update the X path in failing test

### DIFF
--- a/src/test/java/com/mathworks/ci/systemtests/RunMatlabBuildIT.java
+++ b/src/test/java/com/mathworks/ci/systemtests/RunMatlabBuildIT.java
@@ -247,7 +247,7 @@ public class RunMatlabBuildIT {
 
     private String getSummaryFromBuildStatus(FreeStyleBuild build) throws IOException, SAXException {
         HtmlPage buildPage = jenkins.createWebClient().getPage(build);
-        HtmlElement summaryElement = (HtmlElement) buildPage.getByXPath("//*[@id='main-panel']/table[1]/tbody/tr[3]/td[2]").get(0);
+        HtmlElement summaryElement = (HtmlElement) buildPage.getByXPath("//div[starts-with(@id, 'buildresults')]").get(0);
         return summaryElement.getTextContent();
 
     }


### PR DESCRIPTION
The failing test workflow seems to be working fine when checked on Linux machine. I updated the XPath to get the summary using the 'id' of the summary element 'div'. This would be more robust.