### PR TITLE
Update codeowners and set compatibleSinceVersion property

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jenkinsci/matlab-plugin-developers
+* @davidbuzinski @mw-hrastega @mw-kapilg @sameagen-MW @tsharmaMW @Vahila

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
 		<!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
 		<jenkins.baseline>2.387</jenkins.baseline>
 		<jenkins.version>${jenkins.baseline}.3</jenkins.version>
+		<hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
Update CODEOWNERS:
Shifted to using individual usernames as adding users who are not part of 'jenkinsci' org would require an invite from Jenkins community which would be an extra dependency. Individual usernames can be used as long as users have write permission to the repo(which can be done by anyone with admin access.)

Set compatibleSinceVersion:
Set the '<hpi.compatibleSinceVersion>' to 2.0.0. This tells Jenkins that plugin versions prior to 2.0.0 are not backward-compatible, and users running an older release will see a warning before upgrading.