### PR TITLE
Update getDefaultPlugins.m

### DIFF
--- a/src/main/resources/+ciplugins/+jenkins/getDefaultPlugins.m
+++ b/src/main/resources/+ciplugins/+jenkins/getDefaultPlugins.m
@@ -6,7 +6,7 @@ arguments
     pluginProviderData (1,1) struct = struct();
 end
 
-if isMATLABReleaseOlderThan("R2025b")
+if isMATLABReleaseOlderThan("R2026a")
     reportPlugin = ciplugins.jenkins.BuildReportPlugin();
 else
     reportPlugin = ciplugins.jenkins.ParallelizableBuildReportPlugin();


### PR DESCRIPTION
The `runBuild` lifecycle update get moved from R2025b to R2026a due to the outage. As such, we need to update the release being used to select the plugin version in `getDefaultPlugins`.