### PR TITLE
Fix bug with special characters and Windows paths in the parallelizab…

### DIFF
--- a/src/main/resources/+ciplugins/+jenkins/ParallelizableBuildReportPlugin.m
+++ b/src/main/resources/+ciplugins/+jenkins/ParallelizableBuildReportPlugin.m
@@ -52,7 +52,7 @@ classdef ParallelizableBuildReportPlugin < matlab.buildtool.plugins.BuildRunnerP
             try
                 save(name, "taskDetail");
             catch e
-                warning("ciplugins:jenkins:BuildReportPlugin:UnableToSaveTrace", "Unable to save an artifact required to create the MATLAB build summary table");
+                warning("ciplugins:jenkins:BuildReportPlugin:UnableToSaveTrace", "Unable to save an artifact needed for the build summary.");
             end
         end
 
@@ -66,7 +66,7 @@ classdef ParallelizableBuildReportPlugin < matlab.buildtool.plugins.BuildRunnerP
             try
                 save(name, "taskDetail");
             catch e
-                warning("ciplugins:jenkins:BuildReportPlugin:UnableToSaveTrace", "Unable to save an artifact required to create the MATLAB build summary table");
+                warning("ciplugins:jenkins:BuildReportPlugin:UnableToSaveTrace", "Unable to save an artifact needed for the build summary.");
             end
         end
     end

--- a/src/main/resources/+ciplugins/+jenkins/ParallelizableBuildReportPlugin.m
+++ b/src/main/resources/+ciplugins/+jenkins/ParallelizableBuildReportPlugin.m
@@ -46,7 +46,7 @@ classdef ParallelizableBuildReportPlugin < matlab.buildtool.plugins.BuildRunnerP
         function runTask(plugin, pluginData)
             runTask@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
 
-            name = fullfile(plugin.TempFolder, matlab.lang.internal.uuid() + ".mat");
+            name = fullfile(plugin.TempFolder, matlab.lang.makeValidName(pluginData.Name) + ".mat");
             taskDetail = getCommonTaskDetail(pluginData);
 
             try
@@ -59,7 +59,7 @@ classdef ParallelizableBuildReportPlugin < matlab.buildtool.plugins.BuildRunnerP
         function skipTask(plugin, pluginData)
             skipTask@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
 
-            name = fullfile(plugin.TempFolder, matlab.lang.internal.uuid() + ".mat");
+            name = fullfile(plugin.TempFolder, matlab.lang.makeValidName(pluginData.Name) + ".mat");
             taskDetail = getCommonTaskDetail(pluginData);
             taskDetail.skipReason = pluginData.SkipReason;
 

--- a/src/main/resources/+ciplugins/+jenkins/ParallelizableBuildReportPlugin.m
+++ b/src/main/resources/+ciplugins/+jenkins/ParallelizableBuildReportPlugin.m
@@ -1,6 +1,6 @@
 classdef ParallelizableBuildReportPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
 
-    %   Copyright 2025 The MathWorks, Inc.
+    %   Copyright 2025-2026 The MathWorks, Inc.
 
     properties
         TempFolder
@@ -46,18 +46,28 @@ classdef ParallelizableBuildReportPlugin < matlab.buildtool.plugins.BuildRunnerP
         function runTask(plugin, pluginData)
             runTask@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
 
-            name = fullfile(plugin.TempFolder, pluginData.Name + ".mat");
+            name = fullfile(plugin.TempFolder, matlab.lang.internal.uuid() + ".mat");
             taskDetail = getCommonTaskDetail(pluginData);
-            save(name, "taskDetail");
+
+            try
+                save(name, "taskDetail");
+            catch e
+                warning("ciplugins:jenkins:BuildReportPlugin:UnableToSaveTrace", "Unable to save an artifact required to create the MATLAB build summary table");
+            end
         end
 
         function skipTask(plugin, pluginData)
             skipTask@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
 
-            name = fullfile(plugin.TempFolder, pluginData.Name + ".mat");
+            name = fullfile(plugin.TempFolder, matlab.lang.internal.uuid() + ".mat");
             taskDetail = getCommonTaskDetail(pluginData);
             taskDetail.skipReason = pluginData.SkipReason;
-            save(name, "taskDetail");
+
+            try
+                save(name, "taskDetail");
+            catch e
+                warning("ciplugins:jenkins:BuildReportPlugin:UnableToSaveTrace", "Unable to save an artifact required to create the MATLAB build summary table");
+            end
         end
     end
 end


### PR DESCRIPTION
Currently the plugin uses the task name to determine the name of the file to save the task detail in. For example, a task t1 will have it's detail saved as t1.mat.

This causes issues with tasks that are part of a task group on Windows, since : is not a valid character that can be used for file names. For example mex:myfile.mat is not a valid file name.

This change switches over to using UUIDs instead, and also adds a bit of robustness so failing to save a detail will throw a warning but not stop the build.