### PR TITLE
Store test results in separate files per session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,6 @@ src/main/resources/license.txt
 .idea/
 matlab.iml
 
+.claude/
+
 **/.DS_Store

--- a/src/main/java/com/mathworks/ci/TestResultsViewAction.java
+++ b/src/main/java/com/mathworks/ci/TestResultsViewAction.java
@@ -72,44 +72,94 @@ public class TestResultsViewAction implements RunAction2 {
 
     public List<List<MatlabTestFile>> getTestResults() throws ParseException, InterruptedException, IOException {
         List<List<MatlabTestFile>> testResults = new ArrayList<>();
-        FilePath fl = new FilePath(this.build.getRootDir()).child(MatlabBuilderConstants.TEST_RESULTS_VIEW_ARTIFACT + this.actionID + ".json");
-        try (InputStreamReader reader = new InputStreamReader(Files.newInputStream(Paths.get(fl.toURI())), StandardCharsets.UTF_8)) {
-            this.totalCount = 0;
-            this.passedCount = 0;
-            this.failedCount = 0;
-            this.incompleteCount = 0;
-            this.notRunCount = 0;
 
+        this.totalCount = 0;
+        this.passedCount = 0;
+        this.failedCount = 0;
+        this.incompleteCount = 0;
+        this.notRunCount = 0;
+
+        FilePath buildRoot = new FilePath(this.build.getRootDir());
+        FilePath[] sessionFiles = buildRoot.list(
+                MatlabBuilderConstants.TEST_RESULTS_VIEW_ARTIFACT + this.actionID + "_*.json");
+
+        if (sessionFiles.length > 0) {
+            for (FilePath sessionFile : sessionFiles) {
+                parseSessionFile(sessionFile, testResults);
+            }
+        } else {
+            // Backward compatibility: fall back to legacy single-file format
+            FilePath legacyFile = buildRoot.child(
+                    MatlabBuilderConstants.TEST_RESULTS_VIEW_ARTIFACT + this.actionID + ".json");
+            if (legacyFile.exists()) {
+                parseLegacyFile(legacyFile, testResults);
+            }
+        }
+
+        return testResults;
+    }
+
+    private void parseSessionFile(FilePath sessionFile, List<List<MatlabTestFile>> testResults) throws IOException, InterruptedException {
+        try (InputStreamReader reader = new InputStreamReader(
+                Files.newInputStream(Paths.get(sessionFile.toURI())), StandardCharsets.UTF_8)) {
+            Object parsed = new JSONParser().parse(reader);
+
+            List<MatlabTestFile> testSessionResults = new ArrayList<>();
+            Map<String, MatlabTestFile> map = new HashMap<>();
+
+            if (parsed instanceof JSONArray) {
+                JSONArray jsonTestSessionResultsArray = (JSONArray) parsed;
+                Iterator<JSONObject> testSessionResultsIterator = jsonTestSessionResultsArray.iterator();
+
+                while (testSessionResultsIterator.hasNext()) {
+                    JSONObject jsonTestCase = testSessionResultsIterator.next();
+                    getTestSessionResults(testSessionResults, jsonTestCase, map);
+                }
+            } else if (parsed instanceof JSONObject) {
+                JSONObject jsonTestCase = (JSONObject) parsed;
+                getTestSessionResults(testSessionResults, jsonTestCase, map);
+            }
+
+            testResults.add(testSessionResults);
+        } catch (InterruptedException | IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException(e.getLocalizedMessage());
+        }
+    }
+
+    private void parseLegacyFile(FilePath legacyFile, List<List<MatlabTestFile>> testResults) throws IOException, InterruptedException {
+        try (InputStreamReader reader = new InputStreamReader(
+                Files.newInputStream(Paths.get(legacyFile.toURI())), StandardCharsets.UTF_8)) {
             JSONArray testArtifact = (JSONArray) new JSONParser().parse(reader);
-            Iterator<JSONArray> testArtifactIterator = testArtifact.iterator();
+            Iterator<Object> testArtifactIterator = testArtifact.iterator();
 
-            while(testArtifactIterator.hasNext()){
+            while (testArtifactIterator.hasNext()) {
                 Object jsonTestSessionResults = testArtifactIterator.next();
 
                 List<MatlabTestFile> testSessionResults = new ArrayList<>();
                 Map<String, MatlabTestFile> map = new HashMap<>();
 
-                if(jsonTestSessionResults instanceof JSONArray){
+                if (jsonTestSessionResults instanceof JSONArray) {
                     JSONArray jsonTestSessionResultsArray = (JSONArray) jsonTestSessionResults;
                     Iterator<JSONObject> testSessionResultsIterator = jsonTestSessionResultsArray.iterator();
 
-                    while(testSessionResultsIterator.hasNext()){
+                    while (testSessionResultsIterator.hasNext()) {
                         JSONObject jsonTestCase = testSessionResultsIterator.next();
                         getTestSessionResults(testSessionResults, jsonTestCase, map);
                     }
-                }
-                else if(jsonTestSessionResults instanceof JSONObject) {
+                } else if (jsonTestSessionResults instanceof JSONObject) {
                     JSONObject jsonTestCase = (JSONObject) jsonTestSessionResults;
                     getTestSessionResults(testSessionResults, jsonTestCase, map);
                 }
 
                 testResults.add(testSessionResults);
             }
+        } catch (InterruptedException | IOException e) {
+            throw e;
         } catch (Exception e) {
             throw new IOException(e.getLocalizedMessage());
         }
-
-        return testResults;
     }
 
     private void getTestSessionResults(List<MatlabTestFile> testSessionResults, JSONObject jsonTestCase, Map<String, MatlabTestFile> map) throws IOException, InterruptedException {

--- a/src/main/java/com/mathworks/ci/TestResultsViewAction.java
+++ b/src/main/java/com/mathworks/ci/TestResultsViewAction.java
@@ -34,7 +34,7 @@ import jenkins.model.RunAction2;
 
 public class TestResultsViewAction implements RunAction2 {
     private transient Run<?, ?> build;
-    private FilePath workspace;
+    private String workspacePath;
     private String actionID;
     private int totalCount;
     private int passedCount;
@@ -51,7 +51,7 @@ public class TestResultsViewAction implements RunAction2 {
 
     public TestResultsViewAction(Run<?, ?> build, FilePath workspace, String actionID) throws InterruptedException, IOException {
         this.build = build;
-        this.workspace = workspace;
+        this.workspacePath = workspace.getRemote();
         this.actionID = actionID;
         
         this.totalCount = 0;
@@ -182,7 +182,7 @@ public class TestResultsViewAction implements RunAction2 {
 
         // Find relative path
         Path baseFolderPath = Paths.get(baseFolder.getRemote());
-        Path workspacePath = Paths.get(this.workspace.getRemote());
+        Path workspacePath = Paths.get(this.workspacePath);
         Path relativePath = workspacePath.relativize(baseFolderPath);
         Path normalizedPath = relativePath.normalize();
 
@@ -273,8 +273,8 @@ public class TestResultsViewAction implements RunAction2 {
         return "document.png";
     }
 
-    public FilePath getWorkspace() {
-        return this.workspace;
+    public String getWorkspacePath() {
+        return this.workspacePath;
     }
 
     public String getActionID() {

--- a/src/main/java/com/mathworks/ci/actions/MatlabAction.java
+++ b/src/main/java/com/mathworks/ci/actions/MatlabAction.java
@@ -57,6 +57,7 @@ public class MatlabAction {
         runner.addEnvironmentVariable(
                 "MW_MATLAB_TEMP_FOLDER",
                 runner.getTempFolder().toString());
+        runner.addEnvironmentVariable("MW_MATLAB_ACTION_ID", this.getActionID());
 
         if(this.annotator != null) {
             runner.addEnvironmentVariable(
@@ -69,10 +70,10 @@ public class MatlabAction {
     public void teardownAction(MatlabActionParameters params) {
         // Handle build result
         if(this.annotator != null) {
-            moveJsonArtifactToBuildRoot(params, MatlabBuilderConstants.BUILD_ARTIFACT);
+            moveBuildArtifactToBuildRoot(params);
         }
 
-        moveJsonArtifactToBuildRoot(params, MatlabBuilderConstants.TEST_RESULTS_VIEW_ARTIFACT);
+        moveTestResultsToBuildRoot(params);
 
         try {
             this.runner.removeTempFolder();
@@ -81,29 +82,42 @@ public class MatlabAction {
         }
     }
 
-    private void moveJsonArtifactToBuildRoot(MatlabActionParameters params, String artifactBaseName) {
+    private void moveBuildArtifactToBuildRoot(MatlabActionParameters params) {
         try {
-            FilePath file = new FilePath(this.runner.getTempFolder(), artifactBaseName + ".json");
+            FilePath file = new FilePath(this.runner.getTempFolder(), MatlabBuilderConstants.BUILD_ARTIFACT + ".json");
             if (file.exists()) {
                 Run<?, ?> build = params.getBuild();
-                FilePath workspace = params.getWorkspace();
 
                 FilePath rootLocation = new FilePath(
                         new File(
                                 build.getRootDir().getAbsolutePath(),
-                                artifactBaseName + this.getActionID() + ".json"));
+                                MatlabBuilderConstants.BUILD_ARTIFACT + this.getActionID() + ".json"));
                 file.copyTo(rootLocation);
                 file.delete();
-                
-                switch (artifactBaseName) {
-                    case MatlabBuilderConstants.BUILD_ARTIFACT:
-                        build.addAction(new BuildArtifactAction(build, this.getActionID()));
-                        break;
-                    case MatlabBuilderConstants.TEST_RESULTS_VIEW_ARTIFACT:
-                        build.addAction(new TestResultsViewAction(build, workspace, this.getActionID()));
-                        break;
-                    default:
+                build.addAction(new BuildArtifactAction(build, this.getActionID()));
+            }
+        } catch (Exception e) {
+            System.err.println(e.toString());
+        }
+    }
+
+    private void moveTestResultsToBuildRoot(MatlabActionParameters params) {
+        try {
+            FilePath tempFolder = this.runner.getTempFolder();
+            FilePath[] sessionFiles = tempFolder.list(
+                    MatlabBuilderConstants.TEST_RESULTS_VIEW_ARTIFACT + this.getActionID() + "_*.json");
+
+            if (sessionFiles.length > 0) {
+                Run<?, ?> build = params.getBuild();
+                FilePath workspace = params.getWorkspace();
+                String buildRootPath = build.getRootDir().getAbsolutePath();
+
+                for (FilePath sessionFile : sessionFiles) {
+                    FilePath rootLocation = new FilePath(new File(buildRootPath, sessionFile.getName()));
+                    sessionFile.copyTo(rootLocation);
+                    sessionFile.delete();
                 }
+                build.addAction(new TestResultsViewAction(build, workspace, this.getActionID()));
             }
         } catch (Exception e) {
             // Don't want to override more important error

--- a/src/main/java/com/mathworks/ci/actions/MatlabAction.java
+++ b/src/main/java/com/mathworks/ci/actions/MatlabAction.java
@@ -63,7 +63,6 @@ public class MatlabAction {
             runner.addEnvironmentVariable(
                     "MW_MATLAB_BUILDTOOL_DEFAULT_PLUGINS_FCN_OVERRIDE",
                     "ciplugins.jenkins.getDefaultPlugins");
-            runner.addEnvironmentVariable("MW_BUILD_PLUGIN_ACTION_ID", this.getActionID());
         }
     }
 

--- a/src/main/resources/+ciplugins/+jenkins/TaskRunProgressPlugin.m
+++ b/src/main/resources/+ciplugins/+jenkins/TaskRunProgressPlugin.m
@@ -6,12 +6,12 @@ classdef TaskRunProgressPlugin < matlab.buildtool.plugins.BuildRunnerPlugin
     methods (Access=protected)
 
         function runTask(plugin, pluginData)
-            disp("[MATLAB-Build-" + pluginData.TaskResults.Name + "-" + getenv('MW_BUILD_PLUGIN_ACTION_ID') +"]");
+            disp("[MATLAB-Build-" + pluginData.TaskResults.Name + "-" + getenv('MW_MATLAB_ACTION_ID') +"]");
             runTask@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
         end
 
         function skipTask(plugin, pluginData)
-            disp("[MATLAB-Build-" + pluginData.TaskResults.Name + "-" + getenv('MW_BUILD_PLUGIN_ACTION_ID') +"]");
+            disp("[MATLAB-Build-" + pluginData.TaskResults.Name + "-" + getenv('MW_MATLAB_ACTION_ID') +"]");
             skipTask@matlab.buildtool.plugins.BuildRunnerPlugin(plugin, pluginData);
         end
     end

--- a/src/main/resources/+ciplugins/+jenkins/TestResultsViewPlugin.m
+++ b/src/main/resources/+ciplugins/+jenkins/TestResultsViewPlugin.m
@@ -22,17 +22,14 @@ classdef TestResultsViewPlugin < matlab.unittest.plugins.TestRunnerPlugin
                 testDetails(idx).BaseFolder = pluginData.TestSuite(idx).BaseFolder;
             end
 
-            % If test results artifact exists, update the same file
-            testArtifactFile = fullfile(getenv("MW_MATLAB_TEMP_FOLDER"),"matlabTestResults.json");
-            if isfile(testArtifactFile)
-                testResults = {jsondecode(fileread(testArtifactFile))};
-            else
-                testResults = {};
-            end
-            testResults{end+1} = testDetails;
+            % Write test results for this session to a unique file
+            tempFolder = getenv("MW_MATLAB_TEMP_FOLDER");
+            actionID = getenv("MW_MATLAB_ACTION_ID");
+            timestamp = string(datetime('now', 'Format', 'yyyyMMdd_HHmmss_SSS'));
+            testArtifactFile = fullfile(tempFolder, "matlabTestResults" + actionID + "_" + timestamp + ".json");
 
             try
-                jsonTestResults = jsonencode(testResults, "PrettyPrint", true);
+                jsonTestResults = jsonencode(testDetails, "PrettyPrint", true);
 
                 [fID, msg] = fopen(testArtifactFile, "w");
                 if fID == -1

--- a/src/main/resources/com/mathworks/ci/TestResultsViewAction/index.jelly
+++ b/src/main/resources/com/mathworks/ci/TestResultsViewAction/index.jelly
@@ -36,8 +36,13 @@
                 </br><br />Not Run</p>
             </button>
 
+            <j:set var="sessionIndex" value="${0}"/>
             <j:forEach var="testSession" items="${it.testResults}" varStatus="status">
               <j:if test="${!testSession.isEmpty()}">
+                <j:set var="sessionIndex" value="${sessionIndex + 1}"/>
+                <j:if test="${it.testResults.size() > 1}">
+                  <h3>Test Session ${sessionIndex}</h3>
+                </j:if>
                 <table class="jenkins-table sortable" id="testResultsTable">
                     <thead>
                         <tr>

--- a/src/main/resources/com/mathworks/ci/TestResultsViewAction/index.jelly
+++ b/src/main/resources/com/mathworks/ci/TestResultsViewAction/index.jelly
@@ -37,6 +37,7 @@
             </button>
 
             <j:forEach var="testSession" items="${it.testResults}" varStatus="status">
+              <j:if test="${!testSession.isEmpty()}">
                 <table class="jenkins-table sortable" id="testResultsTable">
                     <thead>
                         <tr>
@@ -143,6 +144,7 @@
                         </j:forEach>
                     </tbody>
                 </table>
+              </j:if>
             </j:forEach>
         </l:main-panel>
     </l:layout>

--- a/src/test/java/com/mathworks/ci/TestResultsViewActionTest.java
+++ b/src/test/java/com/mathworks/ci/TestResultsViewActionTest.java
@@ -339,6 +339,16 @@ public class TestResultsViewActionTest {
     }
 
     @Test
+    public void verifyLegacySingleFileFormat() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
+        TestResultsViewAction ac = setupTestResultsViewActionLegacy();
+        List<List<MatlabTestFile>> ta = ac.getTestResults();
+        Assert.assertEquals("Incorrect test sessions", 2, ta.size());
+        Assert.assertEquals("Incorrect total tests count", 10, ac.getTotalCount());
+        Assert.assertEquals("Incorrect passed tests count", 4, ac.getPassedCount());
+        Assert.assertEquals("Incorrect failed tests count", 3, ac.getFailedCount());
+    }
+
+    @Test
     public void verifyTestResultWithMissingDetails() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
         TestResultsViewAction ac = setupTestResultsViewActionWithMissingDetails();
         List<List<MatlabTestFile>> ta = ac.getTestResults();
@@ -359,7 +369,6 @@ public class TestResultsViewActionTest {
     private TestResultsViewAction setupTestResultsViewActionWithMissingDetails() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
         FreeStyleBuild build = getFreestyleBuild();
         final String actionID = "abc123";
-        final String targetFile = MatlabBuilderConstants.TEST_RESULTS_VIEW_ARTIFACT + actionID + ".json";
         FilePath artifactRoot = new FilePath(build.getRootDir());
 
         String os = System.getProperty("os.name").toLowerCase();
@@ -378,11 +387,42 @@ public class TestResultsViewActionTest {
             throw new RuntimeException("Unsupported OS: " + os);
         }
         final FilePath workspace = new FilePath(new File(workspaceParent + "workspace"));
-        copyFileInWorkspace("testArtifacts/t2/" + osName + "/" + MatlabBuilderConstants.TEST_RESULTS_VIEW_ARTIFACT + ".json", targetFile, artifactRoot);
+        String resourcePrefix = "testArtifacts/t2/" + osName + "/";
+        copyFileInWorkspace(resourcePrefix + MatlabBuilderConstants.TEST_RESULTS_VIEW_ARTIFACT + actionID + "_20260101_120000_001.json",
+                MatlabBuilderConstants.TEST_RESULTS_VIEW_ARTIFACT + actionID + "_20260101_120000_001.json", artifactRoot);
         return new TestResultsViewAction(build, workspace, actionID);
     }
 
     private TestResultsViewAction setupTestResultsViewAction() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
+        FreeStyleBuild build = getFreestyleBuild();
+        final String actionID = "abc123";
+        FilePath artifactRoot = new FilePath(build.getRootDir());
+
+        String os = System.getProperty("os.name").toLowerCase();
+        String osName = "";
+        String workspaceParent = "";
+        if (os.contains("win")) {
+            osName = "windows";
+            workspaceParent = "C:\\";
+        } else if (os.contains("nix") || os.contains("nux") || os.contains("aix")) {
+            osName = "linux";
+            workspaceParent = "/home/user/";
+        } else if (os.contains("mac")) {
+            osName = "mac";
+            workspaceParent = "/Users/username/";
+        } else {
+            throw new RuntimeException("Unsupported OS: " + os);
+        }
+        final FilePath workspace = new FilePath(new File(workspaceParent + "workspace"));
+        String resourcePrefix = "testArtifacts/t1/" + osName + "/";
+        copyFileInWorkspace(resourcePrefix + MatlabBuilderConstants.TEST_RESULTS_VIEW_ARTIFACT + actionID + "_20260101_120000_001.json",
+                MatlabBuilderConstants.TEST_RESULTS_VIEW_ARTIFACT + actionID + "_20260101_120000_001.json", artifactRoot);
+        copyFileInWorkspace(resourcePrefix + MatlabBuilderConstants.TEST_RESULTS_VIEW_ARTIFACT + actionID + "_20260101_120000_002.json",
+                MatlabBuilderConstants.TEST_RESULTS_VIEW_ARTIFACT + actionID + "_20260101_120000_002.json", artifactRoot);
+        return new TestResultsViewAction(build, workspace, actionID);
+    }
+
+    private TestResultsViewAction setupTestResultsViewActionLegacy() throws ExecutionException, InterruptedException, URISyntaxException, IOException, ParseException {
         FreeStyleBuild build = getFreestyleBuild();
         final String actionID = "abc123";
         final String targetFile = MatlabBuilderConstants.TEST_RESULTS_VIEW_ARTIFACT + actionID + ".json";
@@ -404,7 +444,7 @@ public class TestResultsViewActionTest {
             throw new RuntimeException("Unsupported OS: " + os);
         }
         final FilePath workspace = new FilePath(new File(workspaceParent + "workspace"));
-        copyFileInWorkspace("testArtifacts/t1/" + osName + "/" + MatlabBuilderConstants.TEST_RESULTS_VIEW_ARTIFACT + ".json",targetFile,artifactRoot);
+        copyFileInWorkspace("testArtifacts/t1/" + osName + "/" + MatlabBuilderConstants.TEST_RESULTS_VIEW_ARTIFACT + ".json", targetFile, artifactRoot);
         return new TestResultsViewAction(build, workspace, actionID);
     }
 

--- a/src/test/resources/testArtifacts/t1/linux/matlabTestResultsabc123_20260101_120000_001.json
+++ b/src/test/resources/testArtifacts/t1/linux/matlabTestResultsabc123_20260101_120000_001.json
@@ -2,9 +2,7 @@
   {
     "TestResult": {
       "Duration": 0.1,
-      "Details": {
-        "SimulinkTestManagerResults": []
-      },
+      "Details": {},
       "Name": "TestExamples1/testNonLeapYear",
       "Passed": true,
       "Failed": false,
@@ -15,9 +13,7 @@
   {
     "TestResult": {
       "Duration": 0.11,
-      "Details": {
-        "SimulinkTestManagerResults": []
-      },
+      "Details": {},
       "Name": "TestExamples1/testNonLeapYear2",
       "Passed": true,
       "Failed": false,
@@ -28,9 +24,7 @@
   {
     "TestResult": {
       "Duration": 0.111,
-      "Details": {
-        "SimulinkTestManagerResults": []
-      },
+      "Details": {},
       "Name": "TestExamples1/testNonLeapYear3",
       "Passed": true,
       "Failed": false,
@@ -41,9 +35,7 @@
   {
     "TestResult": {
       "Duration": 0.1111,
-      "Details": {
-        "SimulinkTestManagerResults": []
-      },
+      "Details": {},
       "Name": "TestExamples1/testNonLeapYear4",
       "Passed": true,
       "Failed": false,
@@ -55,22 +47,8 @@
     "TestResult": {
       "Duration": 0.4,
       "Details": {
-        "SimulinkTestManagerResults": [],
         "DiagnosticRecord": {
-          "TestDiagnosticResults": [],
-          "FrameworkDiagnosticResults": {
-            "Artifacts": [],
-            "DiagnosticText": "SampleDiagnosticsText1"
-          },
-          "AdditionalDiagnosticResults": [],
-          "Stack": {
-            "file": "/home/user/workspace/visualization/tests/TestExamples1.m",
-            "name": "TestExamples1.testLeapYear",
-            "line": 35
-          },
           "Event": "SampleDiagnosticsEvent1",
-          "EventScope": "TestMethod",
-          "EventLocation": "TestExamples1/testLeapYear",
           "Report": "SampleDiagnosticsReport1"
         }
       },
@@ -85,22 +63,8 @@
     "TestResult": {
       "Duration": 0.4,
       "Details": {
-        "SimulinkTestManagerResults": [],
         "DiagnosticRecord": {
-          "TestDiagnosticResults": [],
-          "FrameworkDiagnosticResults": {
-            "Artifacts": [],
-            "DiagnosticText": "SampleDiagnosticsText1"
-          },
-          "AdditionalDiagnosticResults": [],
-          "Stack": {
-            "file": "/home/user/workspace/visualization/tests/TestExamples1.m",
-            "name": "TestExamples1.testLeapYear2",
-            "line": 35
-          },
           "Event": "SampleDiagnosticsEvent1",
-          "EventScope": "TestMethod",
-          "EventLocation": "TestExamples1/testLeapYear2",
           "Report": "SampleDiagnosticsReport1"
         }
       },
@@ -115,22 +79,8 @@
     "TestResult": {
       "Duration": 0.4,
       "Details": {
-        "SimulinkTestManagerResults": [],
         "DiagnosticRecord": {
-          "TestDiagnosticResults": [],
-          "FrameworkDiagnosticResults": {
-            "Artifacts": [],
-            "DiagnosticText": "SampleDiagnosticsText1"
-          },
-          "AdditionalDiagnosticResults": [],
-          "Stack": {
-            "file": "/home/user/workspace/visualization/tests/TestExamples1.m",
-            "name": "TestExamples1.testLeapYear3",
-            "line": 35
-          },
           "Event": "SampleDiagnosticsEvent1",
-          "EventScope": "TestMethod",
-          "EventLocation": "TestExamples1/testLeapYear3",
           "Report": "SampleDiagnosticsReport1"
         }
       },
@@ -145,22 +95,8 @@
     "TestResult": {
       "Duration": 0.1,
       "Details": {
-        "SimulinkTestManagerResults": [],
         "DiagnosticRecord": {
-          "TestDiagnosticResults": [],
-          "FrameworkDiagnosticResults": {
-            "Artifacts": [],
-            "DiagnosticText": "SampleDiagnosticsText2"
-          },
-          "AdditionalDiagnosticResults": [],
-          "Stack": {
-            "file": "/home/user/workspace/visualization/tests/TestExamples1.m",
-            "name": "TestExamples1.testValidDateFormat",
-            "line": 35
-          },
           "Event": "SampleDiagnosticsEvent2",
-          "EventScope": "TestMethod",
-          "EventLocation": "TestExamples1/testValidDateFormat",
           "Report": "SampleDiagnosticsReport2"
         }
       },
@@ -174,9 +110,7 @@
   {
     "TestResult": {
       "Duration": 0,
-      "Details": {
-        "SimulinkTestManagerResults": []
-      },
+      "Details": {},
       "Name": "TestExamples1/testInvalidDateFormat",
       "Passed": false,
       "Failed": false,

--- a/src/test/resources/testArtifacts/t1/linux/matlabTestResultsabc123_20260101_120000_001.json
+++ b/src/test/resources/testArtifacts/t1/linux/matlabTestResultsabc123_20260101_120000_001.json
@@ -1,0 +1,187 @@
+[
+  {
+    "TestResult": {
+      "Duration": 0.1,
+      "Details": {
+        "SimulinkTestManagerResults": []
+      },
+      "Name": "TestExamples1/testNonLeapYear",
+      "Passed": true,
+      "Failed": false,
+      "Incomplete": false
+    },
+    "BaseFolder": "/home/user/workspace/visualization/tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.11,
+      "Details": {
+        "SimulinkTestManagerResults": []
+      },
+      "Name": "TestExamples1/testNonLeapYear2",
+      "Passed": true,
+      "Failed": false,
+      "Incomplete": false
+    },
+    "BaseFolder": "/home/user/workspace/visualization/tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.111,
+      "Details": {
+        "SimulinkTestManagerResults": []
+      },
+      "Name": "TestExamples1/testNonLeapYear3",
+      "Passed": true,
+      "Failed": false,
+      "Incomplete": false
+    },
+    "BaseFolder": "/home/user/workspace/visualization/tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.1111,
+      "Details": {
+        "SimulinkTestManagerResults": []
+      },
+      "Name": "TestExamples1/testNonLeapYear4",
+      "Passed": true,
+      "Failed": false,
+      "Incomplete": false
+    },
+    "BaseFolder": "/home/user/workspace/visualization/tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.4,
+      "Details": {
+        "SimulinkTestManagerResults": [],
+        "DiagnosticRecord": {
+          "TestDiagnosticResults": [],
+          "FrameworkDiagnosticResults": {
+            "Artifacts": [],
+            "DiagnosticText": "SampleDiagnosticsText1"
+          },
+          "AdditionalDiagnosticResults": [],
+          "Stack": {
+            "file": "/home/user/workspace/visualization/tests/TestExamples1.m",
+            "name": "TestExamples1.testLeapYear",
+            "line": 35
+          },
+          "Event": "SampleDiagnosticsEvent1",
+          "EventScope": "TestMethod",
+          "EventLocation": "TestExamples1/testLeapYear",
+          "Report": "SampleDiagnosticsReport1"
+        }
+      },
+      "Name": "TestExamples1/testLeapYear",
+      "Passed": false,
+      "Failed": true,
+      "Incomplete": true
+    },
+    "BaseFolder": "/home/user/workspace/visualization/tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.4,
+      "Details": {
+        "SimulinkTestManagerResults": [],
+        "DiagnosticRecord": {
+          "TestDiagnosticResults": [],
+          "FrameworkDiagnosticResults": {
+            "Artifacts": [],
+            "DiagnosticText": "SampleDiagnosticsText1"
+          },
+          "AdditionalDiagnosticResults": [],
+          "Stack": {
+            "file": "/home/user/workspace/visualization/tests/TestExamples1.m",
+            "name": "TestExamples1.testLeapYear2",
+            "line": 35
+          },
+          "Event": "SampleDiagnosticsEvent1",
+          "EventScope": "TestMethod",
+          "EventLocation": "TestExamples1/testLeapYear2",
+          "Report": "SampleDiagnosticsReport1"
+        }
+      },
+      "Name": "TestExamples1/testLeapYear2",
+      "Passed": false,
+      "Failed": true,
+      "Incomplete": true
+    },
+    "BaseFolder": "/home/user/workspace/visualization/tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.4,
+      "Details": {
+        "SimulinkTestManagerResults": [],
+        "DiagnosticRecord": {
+          "TestDiagnosticResults": [],
+          "FrameworkDiagnosticResults": {
+            "Artifacts": [],
+            "DiagnosticText": "SampleDiagnosticsText1"
+          },
+          "AdditionalDiagnosticResults": [],
+          "Stack": {
+            "file": "/home/user/workspace/visualization/tests/TestExamples1.m",
+            "name": "TestExamples1.testLeapYear3",
+            "line": 35
+          },
+          "Event": "SampleDiagnosticsEvent1",
+          "EventScope": "TestMethod",
+          "EventLocation": "TestExamples1/testLeapYear3",
+          "Report": "SampleDiagnosticsReport1"
+        }
+      },
+      "Name": "TestExamples1/testLeapYear3",
+      "Passed": false,
+      "Failed": true,
+      "Incomplete": true
+    },
+    "BaseFolder": "/home/user/workspace/visualization/tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.1,
+      "Details": {
+        "SimulinkTestManagerResults": [],
+        "DiagnosticRecord": {
+          "TestDiagnosticResults": [],
+          "FrameworkDiagnosticResults": {
+            "Artifacts": [],
+            "DiagnosticText": "SampleDiagnosticsText2"
+          },
+          "AdditionalDiagnosticResults": [],
+          "Stack": {
+            "file": "/home/user/workspace/visualization/tests/TestExamples1.m",
+            "name": "TestExamples1.testValidDateFormat",
+            "line": 35
+          },
+          "Event": "SampleDiagnosticsEvent2",
+          "EventScope": "TestMethod",
+          "EventLocation": "TestExamples1/testValidDateFormat",
+          "Report": "SampleDiagnosticsReport2"
+        }
+      },
+      "Name": "TestExamples1/testValidDateFormat",
+      "Passed": false,
+      "Failed": false,
+      "Incomplete": true
+    },
+    "BaseFolder": "/home/user/workspace/visualization/tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0,
+      "Details": {
+        "SimulinkTestManagerResults": []
+      },
+      "Name": "TestExamples1/testInvalidDateFormat",
+      "Passed": false,
+      "Failed": false,
+      "Incomplete": false
+    },
+    "BaseFolder": "/home/user/workspace/visualization/tests"
+  }
+]

--- a/src/test/resources/testArtifacts/t1/linux/matlabTestResultsabc123_20260101_120000_002.json
+++ b/src/test/resources/testArtifacts/t1/linux/matlabTestResultsabc123_20260101_120000_002.json
@@ -1,0 +1,30 @@
+{
+  "TestResult": {
+    "Duration": 0.1,
+    "Details": {
+      "SimulinkTestManagerResults": [],
+      "DiagnosticRecord": {
+        "TestDiagnosticResults": [],
+        "FrameworkDiagnosticResults": {
+          "Artifacts": [],
+          "DiagnosticText": "SampleDiagnosticsText2"
+        },
+        "AdditionalDiagnosticResults": [],
+        "Stack": {
+          "file": "/home/user/workspace/visualization/duplicate_tests/TestExamples2.m",
+          "name": "TestExamples2.testNonLeapYear",
+          "line": 35
+        },
+        "Event": "SampleDiagnosticsEvent2",
+        "EventScope": "TestMethod",
+        "EventLocation": "TestExamples2/testNonLeapYear",
+        "Report": "SampleDiagnosticsReport2"
+      }
+    },
+    "Name": "TestExamples2/testNonLeapYear",
+    "Passed": false,
+    "Failed": false,
+    "Incomplete": true
+  },
+  "BaseFolder": "/home/user/workspace/visualization/duplicate_tests"
+}

--- a/src/test/resources/testArtifacts/t1/linux/matlabTestResultsabc123_20260101_120000_002.json
+++ b/src/test/resources/testArtifacts/t1/linux/matlabTestResultsabc123_20260101_120000_002.json
@@ -2,22 +2,8 @@
   "TestResult": {
     "Duration": 0.1,
     "Details": {
-      "SimulinkTestManagerResults": [],
       "DiagnosticRecord": {
-        "TestDiagnosticResults": [],
-        "FrameworkDiagnosticResults": {
-          "Artifacts": [],
-          "DiagnosticText": "SampleDiagnosticsText2"
-        },
-        "AdditionalDiagnosticResults": [],
-        "Stack": {
-          "file": "/home/user/workspace/visualization/duplicate_tests/TestExamples2.m",
-          "name": "TestExamples2.testNonLeapYear",
-          "line": 35
-        },
         "Event": "SampleDiagnosticsEvent2",
-        "EventScope": "TestMethod",
-        "EventLocation": "TestExamples2/testNonLeapYear",
         "Report": "SampleDiagnosticsReport2"
       }
     },

--- a/src/test/resources/testArtifacts/t1/mac/matlabTestResultsabc123_20260101_120000_001.json
+++ b/src/test/resources/testArtifacts/t1/mac/matlabTestResultsabc123_20260101_120000_001.json
@@ -2,9 +2,7 @@
   {
     "TestResult": {
       "Duration": 0.1,
-      "Details": {
-        "SimulinkTestManagerResults": []
-      },
+      "Details": {},
       "Name": "TestExamples1/testNonLeapYear",
       "Passed": true,
       "Failed": false,
@@ -15,9 +13,7 @@
   {
     "TestResult": {
       "Duration": 0.11,
-      "Details": {
-        "SimulinkTestManagerResults": []
-      },
+      "Details": {},
       "Name": "TestExamples1/testNonLeapYear2",
       "Passed": true,
       "Failed": false,
@@ -28,9 +24,7 @@
   {
     "TestResult": {
       "Duration": 0.111,
-      "Details": {
-        "SimulinkTestManagerResults": []
-      },
+      "Details": {},
       "Name": "TestExamples1/testNonLeapYear3",
       "Passed": true,
       "Failed": false,
@@ -41,9 +35,7 @@
   {
     "TestResult": {
       "Duration": 0.1111,
-      "Details": {
-        "SimulinkTestManagerResults": []
-      },
+      "Details": {},
       "Name": "TestExamples1/testNonLeapYear4",
       "Passed": true,
       "Failed": false,
@@ -55,22 +47,8 @@
     "TestResult": {
       "Duration": 0.4,
       "Details": {
-        "SimulinkTestManagerResults": [],
         "DiagnosticRecord": {
-          "TestDiagnosticResults": [],
-          "FrameworkDiagnosticResults": {
-            "Artifacts": [],
-            "DiagnosticText": "SampleDiagnosticsText1"
-          },
-          "AdditionalDiagnosticResults": [],
-          "Stack": {
-            "file": "/Users/username/workspace/visualization/tests/TestExamples1.m",
-            "name": "TestExamples1.testLeapYear",
-            "line": 35
-          },
           "Event": "SampleDiagnosticsEvent1",
-          "EventScope": "TestMethod",
-          "EventLocation": "TestExamples1/testLeapYear",
           "Report": "SampleDiagnosticsReport1"
         }
       },
@@ -85,22 +63,8 @@
     "TestResult": {
       "Duration": 0.4,
       "Details": {
-        "SimulinkTestManagerResults": [],
         "DiagnosticRecord": {
-          "TestDiagnosticResults": [],
-          "FrameworkDiagnosticResults": {
-            "Artifacts": [],
-            "DiagnosticText": "SampleDiagnosticsText1"
-          },
-          "AdditionalDiagnosticResults": [],
-          "Stack": {
-            "file": "/Users/username/workspace/visualization/tests/TestExamples1.m",
-            "name": "TestExamples1.testLeapYear2",
-            "line": 35
-          },
           "Event": "SampleDiagnosticsEvent1",
-          "EventScope": "TestMethod",
-          "EventLocation": "TestExamples1/testLeapYear2",
           "Report": "SampleDiagnosticsReport1"
         }
       },
@@ -115,22 +79,8 @@
     "TestResult": {
       "Duration": 0.4,
       "Details": {
-        "SimulinkTestManagerResults": [],
         "DiagnosticRecord": {
-          "TestDiagnosticResults": [],
-          "FrameworkDiagnosticResults": {
-            "Artifacts": [],
-            "DiagnosticText": "SampleDiagnosticsText1"
-          },
-          "AdditionalDiagnosticResults": [],
-          "Stack": {
-            "file": "/Users/username/workspace/visualization/tests/TestExamples1.m",
-            "name": "TestExamples1.testLeapYear3",
-            "line": 35
-          },
           "Event": "SampleDiagnosticsEvent1",
-          "EventScope": "TestMethod",
-          "EventLocation": "TestExamples1/testLeapYear3",
           "Report": "SampleDiagnosticsReport1"
         }
       },
@@ -145,22 +95,8 @@
     "TestResult": {
       "Duration": 0.1,
       "Details": {
-        "SimulinkTestManagerResults": [],
         "DiagnosticRecord": {
-          "TestDiagnosticResults": [],
-          "FrameworkDiagnosticResults": {
-            "Artifacts": [],
-            "DiagnosticText": "SampleDiagnosticsText2"
-          },
-          "AdditionalDiagnosticResults": [],
-          "Stack": {
-            "file": "/Users/username/workspace/visualization/tests/TestExamples1.m",
-            "name": "TestExamples1.testValidDateFormat",
-            "line": 35
-          },
           "Event": "SampleDiagnosticsEvent2",
-          "EventScope": "TestMethod",
-          "EventLocation": "TestExamples1/testValidDateFormat",
           "Report": "SampleDiagnosticsReport2"
         }
       },
@@ -174,9 +110,7 @@
   {
     "TestResult": {
       "Duration": 0,
-      "Details": {
-        "SimulinkTestManagerResults": []
-      },
+      "Details": {},
       "Name": "TestExamples1/testInvalidDateFormat",
       "Passed": false,
       "Failed": false,

--- a/src/test/resources/testArtifacts/t1/mac/matlabTestResultsabc123_20260101_120000_001.json
+++ b/src/test/resources/testArtifacts/t1/mac/matlabTestResultsabc123_20260101_120000_001.json
@@ -1,0 +1,187 @@
+[
+  {
+    "TestResult": {
+      "Duration": 0.1,
+      "Details": {
+        "SimulinkTestManagerResults": []
+      },
+      "Name": "TestExamples1/testNonLeapYear",
+      "Passed": true,
+      "Failed": false,
+      "Incomplete": false
+    },
+    "BaseFolder": "/Users/username/workspace/visualization/tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.11,
+      "Details": {
+        "SimulinkTestManagerResults": []
+      },
+      "Name": "TestExamples1/testNonLeapYear2",
+      "Passed": true,
+      "Failed": false,
+      "Incomplete": false
+    },
+    "BaseFolder": "/Users/username/workspace/visualization/tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.111,
+      "Details": {
+        "SimulinkTestManagerResults": []
+      },
+      "Name": "TestExamples1/testNonLeapYear3",
+      "Passed": true,
+      "Failed": false,
+      "Incomplete": false
+    },
+    "BaseFolder": "/Users/username/workspace/visualization/tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.1111,
+      "Details": {
+        "SimulinkTestManagerResults": []
+      },
+      "Name": "TestExamples1/testNonLeapYear4",
+      "Passed": true,
+      "Failed": false,
+      "Incomplete": false
+    },
+    "BaseFolder": "/Users/username/workspace/visualization/tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.4,
+      "Details": {
+        "SimulinkTestManagerResults": [],
+        "DiagnosticRecord": {
+          "TestDiagnosticResults": [],
+          "FrameworkDiagnosticResults": {
+            "Artifacts": [],
+            "DiagnosticText": "SampleDiagnosticsText1"
+          },
+          "AdditionalDiagnosticResults": [],
+          "Stack": {
+            "file": "/Users/username/workspace/visualization/tests/TestExamples1.m",
+            "name": "TestExamples1.testLeapYear",
+            "line": 35
+          },
+          "Event": "SampleDiagnosticsEvent1",
+          "EventScope": "TestMethod",
+          "EventLocation": "TestExamples1/testLeapYear",
+          "Report": "SampleDiagnosticsReport1"
+        }
+      },
+      "Name": "TestExamples1/testLeapYear",
+      "Passed": false,
+      "Failed": true,
+      "Incomplete": true
+    },
+    "BaseFolder": "/Users/username/workspace/visualization/tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.4,
+      "Details": {
+        "SimulinkTestManagerResults": [],
+        "DiagnosticRecord": {
+          "TestDiagnosticResults": [],
+          "FrameworkDiagnosticResults": {
+            "Artifacts": [],
+            "DiagnosticText": "SampleDiagnosticsText1"
+          },
+          "AdditionalDiagnosticResults": [],
+          "Stack": {
+            "file": "/Users/username/workspace/visualization/tests/TestExamples1.m",
+            "name": "TestExamples1.testLeapYear2",
+            "line": 35
+          },
+          "Event": "SampleDiagnosticsEvent1",
+          "EventScope": "TestMethod",
+          "EventLocation": "TestExamples1/testLeapYear2",
+          "Report": "SampleDiagnosticsReport1"
+        }
+      },
+      "Name": "TestExamples1/testLeapYear2",
+      "Passed": false,
+      "Failed": true,
+      "Incomplete": true
+    },
+    "BaseFolder": "/Users/username/workspace/visualization/tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.4,
+      "Details": {
+        "SimulinkTestManagerResults": [],
+        "DiagnosticRecord": {
+          "TestDiagnosticResults": [],
+          "FrameworkDiagnosticResults": {
+            "Artifacts": [],
+            "DiagnosticText": "SampleDiagnosticsText1"
+          },
+          "AdditionalDiagnosticResults": [],
+          "Stack": {
+            "file": "/Users/username/workspace/visualization/tests/TestExamples1.m",
+            "name": "TestExamples1.testLeapYear3",
+            "line": 35
+          },
+          "Event": "SampleDiagnosticsEvent1",
+          "EventScope": "TestMethod",
+          "EventLocation": "TestExamples1/testLeapYear3",
+          "Report": "SampleDiagnosticsReport1"
+        }
+      },
+      "Name": "TestExamples1/testLeapYear3",
+      "Passed": false,
+      "Failed": true,
+      "Incomplete": true
+    },
+    "BaseFolder": "/Users/username/workspace/visualization/tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.1,
+      "Details": {
+        "SimulinkTestManagerResults": [],
+        "DiagnosticRecord": {
+          "TestDiagnosticResults": [],
+          "FrameworkDiagnosticResults": {
+            "Artifacts": [],
+            "DiagnosticText": "SampleDiagnosticsText2"
+          },
+          "AdditionalDiagnosticResults": [],
+          "Stack": {
+            "file": "/Users/username/workspace/visualization/tests/TestExamples1.m",
+            "name": "TestExamples1.testValidDateFormat",
+            "line": 35
+          },
+          "Event": "SampleDiagnosticsEvent2",
+          "EventScope": "TestMethod",
+          "EventLocation": "TestExamples1/testValidDateFormat",
+          "Report": "SampleDiagnosticsReport2"
+        }
+      },
+      "Name": "TestExamples1/testValidDateFormat",
+      "Passed": false,
+      "Failed": false,
+      "Incomplete": true
+    },
+    "BaseFolder": "/Users/username/workspace/visualization/tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0,
+      "Details": {
+        "SimulinkTestManagerResults": []
+      },
+      "Name": "TestExamples1/testInvalidDateFormat",
+      "Passed": false,
+      "Failed": false,
+      "Incomplete": false
+    },
+    "BaseFolder": "/Users/username/workspace/visualization/tests"
+  }
+]

--- a/src/test/resources/testArtifacts/t1/mac/matlabTestResultsabc123_20260101_120000_002.json
+++ b/src/test/resources/testArtifacts/t1/mac/matlabTestResultsabc123_20260101_120000_002.json
@@ -1,0 +1,30 @@
+{
+  "TestResult": {
+    "Duration": 0.1,
+    "Details": {
+      "SimulinkTestManagerResults": [],
+      "DiagnosticRecord": {
+        "TestDiagnosticResults": [],
+        "FrameworkDiagnosticResults": {
+          "Artifacts": [],
+          "DiagnosticText": "SampleDiagnosticsText2"
+        },
+        "AdditionalDiagnosticResults": [],
+        "Stack": {
+          "file": "/Users/username/workspace/visualization/duplicate_tests/TestExamples2.m",
+          "name": "TestExamples2.testNonLeapYear",
+          "line": 35
+        },
+        "Event": "SampleDiagnosticsEvent2",
+        "EventScope": "TestMethod",
+        "EventLocation": "TestExamples2/testNonLeapYear",
+        "Report": "SampleDiagnosticsReport2"
+      }
+    },
+    "Name": "TestExamples2/testNonLeapYear",
+    "Passed": false,
+    "Failed": false,
+    "Incomplete": true
+  },
+  "BaseFolder": "/Users/username/workspace/visualization/duplicate_tests"
+}

--- a/src/test/resources/testArtifacts/t1/mac/matlabTestResultsabc123_20260101_120000_002.json
+++ b/src/test/resources/testArtifacts/t1/mac/matlabTestResultsabc123_20260101_120000_002.json
@@ -2,22 +2,8 @@
   "TestResult": {
     "Duration": 0.1,
     "Details": {
-      "SimulinkTestManagerResults": [],
       "DiagnosticRecord": {
-        "TestDiagnosticResults": [],
-        "FrameworkDiagnosticResults": {
-          "Artifacts": [],
-          "DiagnosticText": "SampleDiagnosticsText2"
-        },
-        "AdditionalDiagnosticResults": [],
-        "Stack": {
-          "file": "/Users/username/workspace/visualization/duplicate_tests/TestExamples2.m",
-          "name": "TestExamples2.testNonLeapYear",
-          "line": 35
-        },
         "Event": "SampleDiagnosticsEvent2",
-        "EventScope": "TestMethod",
-        "EventLocation": "TestExamples2/testNonLeapYear",
         "Report": "SampleDiagnosticsReport2"
       }
     },

--- a/src/test/resources/testArtifacts/t1/windows/matlabTestResultsabc123_20260101_120000_001.json
+++ b/src/test/resources/testArtifacts/t1/windows/matlabTestResultsabc123_20260101_120000_001.json
@@ -1,0 +1,187 @@
+[
+  {
+    "TestResult": {
+      "Duration": 0.1,
+      "Details": {
+        "SimulinkTestManagerResults": []
+      },
+      "Name": "TestExamples1/testNonLeapYear",
+      "Passed": true,
+      "Failed": false,
+      "Incomplete": false
+    },
+    "BaseFolder": "C:\\workspace\\visualization\\tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.11,
+      "Details": {
+        "SimulinkTestManagerResults": []
+      },
+      "Name": "TestExamples1/testNonLeapYear2",
+      "Passed": true,
+      "Failed": false,
+      "Incomplete": false
+    },
+    "BaseFolder": "C:\\workspace\\visualization\\tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.111,
+      "Details": {
+        "SimulinkTestManagerResults": []
+      },
+      "Name": "TestExamples1/testNonLeapYear3",
+      "Passed": true,
+      "Failed": false,
+      "Incomplete": false
+    },
+    "BaseFolder": "C:\\workspace\\visualization\\tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.1111,
+      "Details": {
+        "SimulinkTestManagerResults": []
+      },
+      "Name": "TestExamples1/testNonLeapYear4",
+      "Passed": true,
+      "Failed": false,
+      "Incomplete": false
+    },
+    "BaseFolder": "C:\\workspace\\visualization\\tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.4,
+      "Details": {
+        "SimulinkTestManagerResults": [],
+        "DiagnosticRecord": {
+          "TestDiagnosticResults": [],
+          "FrameworkDiagnosticResults": {
+            "Artifacts": [],
+            "DiagnosticText": "SampleDiagnosticsText1"
+          },
+          "AdditionalDiagnosticResults": [],
+          "Stack": {
+            "file": "C:\\workspace\\visualization\\tests\\TestExamples1.m",
+            "name": "TestExamples1.testLeapYear",
+            "line": 35
+          },
+          "Event": "SampleDiagnosticsEvent1",
+          "EventScope": "TestMethod",
+          "EventLocation": "TestExamples1/testLeapYear",
+          "Report": "SampleDiagnosticsReport1"
+        }
+      },
+      "Name": "TestExamples1/testLeapYear",
+      "Passed": false,
+      "Failed": true,
+      "Incomplete": true
+    },
+    "BaseFolder": "C:\\workspace\\visualization\\tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.4,
+      "Details": {
+        "SimulinkTestManagerResults": [],
+        "DiagnosticRecord": {
+          "TestDiagnosticResults": [],
+          "FrameworkDiagnosticResults": {
+            "Artifacts": [],
+            "DiagnosticText": "SampleDiagnosticsText1"
+          },
+          "AdditionalDiagnosticResults": [],
+          "Stack": {
+            "file": "C:\\workspace\\visualization\\tests\\TestExamples1.m",
+            "name": "TestExamples1.testLeapYear2",
+            "line": 35
+          },
+          "Event": "SampleDiagnosticsEvent1",
+          "EventScope": "TestMethod",
+          "EventLocation": "TestExamples1/testLeapYear2",
+          "Report": "SampleDiagnosticsReport1"
+        }
+      },
+      "Name": "TestExamples1/testLeapYear2",
+      "Passed": false,
+      "Failed": true,
+      "Incomplete": true
+    },
+    "BaseFolder": "C:\\workspace\\visualization\\tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.4,
+      "Details": {
+        "SimulinkTestManagerResults": [],
+        "DiagnosticRecord": {
+          "TestDiagnosticResults": [],
+          "FrameworkDiagnosticResults": {
+            "Artifacts": [],
+            "DiagnosticText": "SampleDiagnosticsText1"
+          },
+          "AdditionalDiagnosticResults": [],
+          "Stack": {
+            "file": "C:\\workspace\\visualization\\tests\\TestExamples1.m",
+            "name": "TestExamples1.testLeapYear3",
+            "line": 35
+          },
+          "Event": "SampleDiagnosticsEvent1",
+          "EventScope": "TestMethod",
+          "EventLocation": "TestExamples1/testLeapYear3",
+          "Report": "SampleDiagnosticsReport1"
+        }
+      },
+      "Name": "TestExamples1/testLeapYear3",
+      "Passed": false,
+      "Failed": true,
+      "Incomplete": true
+    },
+    "BaseFolder": "C:\\workspace\\visualization\\tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0.1,
+      "Details": {
+        "SimulinkTestManagerResults": [],
+        "DiagnosticRecord": {
+          "TestDiagnosticResults": [],
+          "FrameworkDiagnosticResults": {
+            "Artifacts": [],
+            "DiagnosticText": "SampleDiagnosticsText2"
+          },
+          "AdditionalDiagnosticResults": [],
+          "Stack": {
+            "file": "C:\\workspace\\visualization\\tests\\TestExamples1.m",
+            "name": "TestExamples1.testValidDateFormat",
+            "line": 35
+          },
+          "Event": "SampleDiagnosticsEvent2",
+          "EventScope": "TestMethod",
+          "EventLocation": "TestExamples1/testValidDateFormat",
+          "Report": "SampleDiagnosticsReport2"
+        }
+      },
+      "Name": "TestExamples1/testValidDateFormat",
+      "Passed": false,
+      "Failed": false,
+      "Incomplete": true
+    },
+    "BaseFolder": "C:\\workspace\\visualization\\tests"
+  },
+  {
+    "TestResult": {
+      "Duration": 0,
+      "Details": {
+        "SimulinkTestManagerResults": []
+      },
+      "Name": "TestExamples1/testInvalidDateFormat",
+      "Passed": false,
+      "Failed": false,
+      "Incomplete": false
+    },
+    "BaseFolder": "C:\\workspace\\visualization\\tests"
+  }
+]

--- a/src/test/resources/testArtifacts/t1/windows/matlabTestResultsabc123_20260101_120000_001.json
+++ b/src/test/resources/testArtifacts/t1/windows/matlabTestResultsabc123_20260101_120000_001.json
@@ -2,9 +2,7 @@
   {
     "TestResult": {
       "Duration": 0.1,
-      "Details": {
-        "SimulinkTestManagerResults": []
-      },
+      "Details": {},
       "Name": "TestExamples1/testNonLeapYear",
       "Passed": true,
       "Failed": false,
@@ -15,9 +13,7 @@
   {
     "TestResult": {
       "Duration": 0.11,
-      "Details": {
-        "SimulinkTestManagerResults": []
-      },
+      "Details": {},
       "Name": "TestExamples1/testNonLeapYear2",
       "Passed": true,
       "Failed": false,
@@ -28,9 +24,7 @@
   {
     "TestResult": {
       "Duration": 0.111,
-      "Details": {
-        "SimulinkTestManagerResults": []
-      },
+      "Details": {},
       "Name": "TestExamples1/testNonLeapYear3",
       "Passed": true,
       "Failed": false,
@@ -41,9 +35,7 @@
   {
     "TestResult": {
       "Duration": 0.1111,
-      "Details": {
-        "SimulinkTestManagerResults": []
-      },
+      "Details": {},
       "Name": "TestExamples1/testNonLeapYear4",
       "Passed": true,
       "Failed": false,
@@ -55,22 +47,8 @@
     "TestResult": {
       "Duration": 0.4,
       "Details": {
-        "SimulinkTestManagerResults": [],
         "DiagnosticRecord": {
-          "TestDiagnosticResults": [],
-          "FrameworkDiagnosticResults": {
-            "Artifacts": [],
-            "DiagnosticText": "SampleDiagnosticsText1"
-          },
-          "AdditionalDiagnosticResults": [],
-          "Stack": {
-            "file": "C:\\workspace\\visualization\\tests\\TestExamples1.m",
-            "name": "TestExamples1.testLeapYear",
-            "line": 35
-          },
           "Event": "SampleDiagnosticsEvent1",
-          "EventScope": "TestMethod",
-          "EventLocation": "TestExamples1/testLeapYear",
           "Report": "SampleDiagnosticsReport1"
         }
       },
@@ -85,22 +63,8 @@
     "TestResult": {
       "Duration": 0.4,
       "Details": {
-        "SimulinkTestManagerResults": [],
         "DiagnosticRecord": {
-          "TestDiagnosticResults": [],
-          "FrameworkDiagnosticResults": {
-            "Artifacts": [],
-            "DiagnosticText": "SampleDiagnosticsText1"
-          },
-          "AdditionalDiagnosticResults": [],
-          "Stack": {
-            "file": "C:\\workspace\\visualization\\tests\\TestExamples1.m",
-            "name": "TestExamples1.testLeapYear2",
-            "line": 35
-          },
           "Event": "SampleDiagnosticsEvent1",
-          "EventScope": "TestMethod",
-          "EventLocation": "TestExamples1/testLeapYear2",
           "Report": "SampleDiagnosticsReport1"
         }
       },
@@ -115,22 +79,8 @@
     "TestResult": {
       "Duration": 0.4,
       "Details": {
-        "SimulinkTestManagerResults": [],
         "DiagnosticRecord": {
-          "TestDiagnosticResults": [],
-          "FrameworkDiagnosticResults": {
-            "Artifacts": [],
-            "DiagnosticText": "SampleDiagnosticsText1"
-          },
-          "AdditionalDiagnosticResults": [],
-          "Stack": {
-            "file": "C:\\workspace\\visualization\\tests\\TestExamples1.m",
-            "name": "TestExamples1.testLeapYear3",
-            "line": 35
-          },
           "Event": "SampleDiagnosticsEvent1",
-          "EventScope": "TestMethod",
-          "EventLocation": "TestExamples1/testLeapYear3",
           "Report": "SampleDiagnosticsReport1"
         }
       },
@@ -145,22 +95,8 @@
     "TestResult": {
       "Duration": 0.1,
       "Details": {
-        "SimulinkTestManagerResults": [],
         "DiagnosticRecord": {
-          "TestDiagnosticResults": [],
-          "FrameworkDiagnosticResults": {
-            "Artifacts": [],
-            "DiagnosticText": "SampleDiagnosticsText2"
-          },
-          "AdditionalDiagnosticResults": [],
-          "Stack": {
-            "file": "C:\\workspace\\visualization\\tests\\TestExamples1.m",
-            "name": "TestExamples1.testValidDateFormat",
-            "line": 35
-          },
           "Event": "SampleDiagnosticsEvent2",
-          "EventScope": "TestMethod",
-          "EventLocation": "TestExamples1/testValidDateFormat",
           "Report": "SampleDiagnosticsReport2"
         }
       },
@@ -174,9 +110,7 @@
   {
     "TestResult": {
       "Duration": 0,
-      "Details": {
-        "SimulinkTestManagerResults": []
-      },
+      "Details": {},
       "Name": "TestExamples1/testInvalidDateFormat",
       "Passed": false,
       "Failed": false,

--- a/src/test/resources/testArtifacts/t1/windows/matlabTestResultsabc123_20260101_120000_002.json
+++ b/src/test/resources/testArtifacts/t1/windows/matlabTestResultsabc123_20260101_120000_002.json
@@ -2,22 +2,8 @@
   "TestResult": {
     "Duration": 0.1,
     "Details": {
-      "SimulinkTestManagerResults": [],
       "DiagnosticRecord": {
-        "TestDiagnosticResults": [],
-        "FrameworkDiagnosticResults": {
-          "Artifacts": [],
-          "DiagnosticText": "SampleDiagnosticsText2"
-        },
-        "AdditionalDiagnosticResults": [],
-        "Stack": {
-          "file": "C:\\workspace\\visualization\\duplicate_tests\\TestExamples2.m",
-          "name": "TestExamples2.testNonLeapYear",
-          "line": 35
-        },
         "Event": "SampleDiagnosticsEvent2",
-        "EventScope": "TestMethod",
-        "EventLocation": "TestExamples2/testNonLeapYear",
         "Report": "SampleDiagnosticsReport2"
       }
     },

--- a/src/test/resources/testArtifacts/t1/windows/matlabTestResultsabc123_20260101_120000_002.json
+++ b/src/test/resources/testArtifacts/t1/windows/matlabTestResultsabc123_20260101_120000_002.json
@@ -1,0 +1,30 @@
+{
+  "TestResult": {
+    "Duration": 0.1,
+    "Details": {
+      "SimulinkTestManagerResults": [],
+      "DiagnosticRecord": {
+        "TestDiagnosticResults": [],
+        "FrameworkDiagnosticResults": {
+          "Artifacts": [],
+          "DiagnosticText": "SampleDiagnosticsText2"
+        },
+        "AdditionalDiagnosticResults": [],
+        "Stack": {
+          "file": "C:\\workspace\\visualization\\duplicate_tests\\TestExamples2.m",
+          "name": "TestExamples2.testNonLeapYear",
+          "line": 35
+        },
+        "Event": "SampleDiagnosticsEvent2",
+        "EventScope": "TestMethod",
+        "EventLocation": "TestExamples2/testNonLeapYear",
+        "Report": "SampleDiagnosticsReport2"
+      }
+    },
+    "Name": "TestExamples2/testNonLeapYear",
+    "Passed": false,
+    "Failed": false,
+    "Incomplete": true
+  },
+  "BaseFolder": "C:\\workspace\\visualization\\duplicate_tests"
+}

--- a/src/test/resources/testArtifacts/t2/linux/matlabTestResultsabc123_20260101_120000_001.json
+++ b/src/test/resources/testArtifacts/t2/linux/matlabTestResultsabc123_20260101_120000_001.json
@@ -1,0 +1,12 @@
+[
+  {
+    "TestResult": {
+      "Duration": 0.1,
+      "Name": "TestExamples1/testNonLeapYear",
+      "Passed": true,
+      "Failed": false,
+      "Incomplete": false
+    },
+    "BaseFolder": "/home/user/workspace/visualization/tests"
+  }
+]

--- a/src/test/resources/testArtifacts/t2/mac/matlabTestResultsabc123_20260101_120000_001.json
+++ b/src/test/resources/testArtifacts/t2/mac/matlabTestResultsabc123_20260101_120000_001.json
@@ -1,0 +1,12 @@
+[
+  {
+    "TestResult": {
+      "Duration": 0.1,
+      "Name": "TestExamples1/testNonLeapYear",
+      "Passed": true,
+      "Failed": false,
+      "Incomplete": false
+    },
+    "BaseFolder": "/Users/username/workspace/visualization/tests"
+  }
+]

--- a/src/test/resources/testArtifacts/t2/windows/matlabTestResultsabc123_20260101_120000_001.json
+++ b/src/test/resources/testArtifacts/t2/windows/matlabTestResultsabc123_20260101_120000_001.json
@@ -1,0 +1,12 @@
+[
+  {
+    "TestResult": {
+      "Duration": 0.1,
+      "Name": "TestExamples1/testNonLeapYear",
+      "Passed": true,
+      "Failed": false,
+      "Incomplete": false
+    },
+    "BaseFolder": "C:\\workspace\\visualization\\tests"
+  }
+]


### PR DESCRIPTION
 ## Summary
- **MATLAB side**: Each test session now writes its own JSON file (`matlabTestResults{actionID}_{timestamp}.json`) instead of all sessions read-modify-writing a single shared file. This eliminates data corruption from concurrent encoding/decoding.
- **Java side**: `MatlabAction` sets `MW_MATLAB_ACTION_ID` env var and copies per-session files as-is to build root. `TestResultsViewAction` reads each file as a separate session, with backward compatibility for the legacy single-file format.
- **Serialization fix**: `TestResultsViewAction.workspace` changed from `FilePath` (not serializable) to `String workspacePath`.
- **View fix**: Empty test sessions no longer render empty table headers.

## Test plan
  - [x] Verify test results display correctly for a single test session
  - [x] Verify test results display correctly for multiple test sessions
  - [x] Verify backward compatibility with existing builds (old single-file format)
  - [x] Verify empty JSON files do not cause rendering issues
  - [x] Verify no serialization warnings in Jenkins logs