### PR TITLE
Add generateSummary option to control result summary generation

### DIFF
--- a/src/main/java/com/mathworks/ci/actions/MatlabAction.java
+++ b/src/main/java/com/mathworks/ci/actions/MatlabAction.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.actions;
 
 /**
- * Copyright 2024-2025, The MathWorks Inc.
+ * Copyright 2024-26, The MathWorks Inc.
  */
 
 import com.mathworks.ci.BuildArtifactAction;
@@ -38,22 +38,25 @@ public class MatlabAction {
         this.annotator = annotator;
     }
 
-    public void copyBuildPluginsToTemp() throws IOException, InterruptedException {
-        // Copy BuildRunner plugins and override default plugins function
+    public void copyPluginsToTemp(boolean generateSummary) throws IOException, InterruptedException {
         if(this.annotator != null) {
             runner.copyFileToTempFolder(MatlabBuilderConstants.DEFAULT_PLUGIN, MatlabBuilderConstants.DEFAULT_PLUGIN);
-            runner.copyFileToTempFolder(MatlabBuilderConstants.BUILD_REPORT_PLUGIN, MatlabBuilderConstants.BUILD_REPORT_PLUGIN);
-            runner.copyFileToTempFolder(MatlabBuilderConstants.PAR_BUILD_REPORT_PLUGIN, MatlabBuilderConstants.PAR_BUILD_REPORT_PLUGIN);
             runner.copyFileToTempFolder(MatlabBuilderConstants.TASK_RUN_PROGRESS_PLUGIN, MatlabBuilderConstants.TASK_RUN_PROGRESS_PLUGIN);
+
+            if (generateSummary) {
+                runner.copyFileToTempFolder(MatlabBuilderConstants.BUILD_REPORT_PLUGIN, MatlabBuilderConstants.BUILD_REPORT_PLUGIN);
+                runner.copyFileToTempFolder(MatlabBuilderConstants.PAR_BUILD_REPORT_PLUGIN, MatlabBuilderConstants.PAR_BUILD_REPORT_PLUGIN);
+            }
         }
 
-        // Copy TestRunner plugins and services
-        runner.copyFileToTempFolder(MatlabBuilderConstants.TEST_RESULTS_VIEW_PLUGIN, MatlabBuilderConstants.TEST_RESULTS_VIEW_PLUGIN);
-        runner.copyFileToTempFolder(MatlabBuilderConstants.TEST_RESULTS_VIEW_PLUGIN_SERVICE, MatlabBuilderConstants.TEST_RESULTS_VIEW_PLUGIN_SERVICE);
+        // Copy TestRunner plugins and services (only for summary generation)
+        if (generateSummary) {
+            runner.copyFileToTempFolder(MatlabBuilderConstants.TEST_RESULTS_VIEW_PLUGIN, MatlabBuilderConstants.TEST_RESULTS_VIEW_PLUGIN);
+            runner.copyFileToTempFolder(MatlabBuilderConstants.TEST_RESULTS_VIEW_PLUGIN_SERVICE, MatlabBuilderConstants.TEST_RESULTS_VIEW_PLUGIN_SERVICE);
+        }
     }
 
-    public void setBuildEnvVars() throws IOException, InterruptedException {
-        // Set environment variable
+    public void setBuildEnvVars(boolean generateSummary) throws IOException, InterruptedException {
         runner.addEnvironmentVariable(
                 "MW_MATLAB_TEMP_FOLDER",
                 runner.getTempFolder().toString());
@@ -63,16 +66,21 @@ public class MatlabAction {
             runner.addEnvironmentVariable(
                     "MW_MATLAB_BUILDTOOL_DEFAULT_PLUGINS_FCN_OVERRIDE",
                     "ciplugins.jenkins.getDefaultPlugins");
+            runner.addEnvironmentVariable(
+                    "MW_GENERATE_SUMMARY",
+                    String.valueOf(generateSummary));
         }
     }
 
     public void teardownAction(MatlabActionParameters params) {
-        // Handle build result
-        if(this.annotator != null) {
-            moveBuildArtifactToBuildRoot(params);
-        }
+        if (params.getGenerateSummary()) {
+            // Handle build result
+            if (this.annotator != null) {
+                moveBuildArtifactToBuildRoot(params);
+            }
 
-        moveTestResultsToBuildRoot(params);
+            moveTestResultsToBuildRoot(params);
+        }
 
         try {
             this.runner.removeTempFolder();

--- a/src/main/java/com/mathworks/ci/actions/MatlabAction.java
+++ b/src/main/java/com/mathworks/ci/actions/MatlabAction.java
@@ -67,7 +67,7 @@ public class MatlabAction {
                     "MW_MATLAB_BUILDTOOL_DEFAULT_PLUGINS_FCN_OVERRIDE",
                     "ciplugins.jenkins.getDefaultPlugins");
             runner.addEnvironmentVariable(
-                    "MW_GENERATE_SUMMARY",
+                    "MW_INPUT_GENERATE_SUMMARY",
                     String.valueOf(generateSummary));
         }
     }

--- a/src/main/java/com/mathworks/ci/actions/RunMatlabBuildAction.java
+++ b/src/main/java/com/mathworks/ci/actions/RunMatlabBuildAction.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.actions;
 
 /**
- * Copyright 2024-25, The MathWorks Inc.
+ * Copyright 2024-26, The MathWorks Inc.
  */
 
 import java.io.IOException;
@@ -29,8 +29,8 @@ public class RunMatlabBuildAction extends MatlabAction {
     }
 
     public void run() throws IOException, InterruptedException, MatlabExecutionException {
-        super.copyBuildPluginsToTemp();
-        super.setBuildEnvVars();
+        super.copyPluginsToTemp(this.params.getGenerateSummary());
+        super.setBuildEnvVars(this.params.getGenerateSummary());
 
         // Redirect output to the build annotator
         runner.redirectStdOut(annotator);

--- a/src/main/java/com/mathworks/ci/actions/RunMatlabCommandAction.java
+++ b/src/main/java/com/mathworks/ci/actions/RunMatlabCommandAction.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.actions;
 
 /**
- * Copyright 2024-25, The MathWorks Inc.
+ * Copyright 2024-26, The MathWorks Inc.
  */
 
 import java.io.IOException;
@@ -29,8 +29,8 @@ public class RunMatlabCommandAction extends MatlabAction {
     }
 
     public void run() throws IOException, InterruptedException, MatlabExecutionException {
-        super.copyBuildPluginsToTemp();
-        super.setBuildEnvVars();
+        super.copyPluginsToTemp(this.params.getGenerateSummary());
+        super.setBuildEnvVars(this.params.getGenerateSummary());
 
         // Redirect output to the build annotator
         runner.redirectStdOut(annotator);

--- a/src/main/java/com/mathworks/ci/actions/RunMatlabTestsAction.java
+++ b/src/main/java/com/mathworks/ci/actions/RunMatlabTestsAction.java
@@ -29,6 +29,7 @@ public class RunMatlabTestsAction extends MatlabAction {
     }
 
     public void run() throws IOException, InterruptedException, MatlabExecutionException {
+        // No annotator in this action, so only test related plugins are copied here
         super.copyPluginsToTemp(this.params.getGenerateSummary());
         super.setBuildEnvVars(this.params.getGenerateSummary());
 

--- a/src/main/java/com/mathworks/ci/actions/RunMatlabTestsAction.java
+++ b/src/main/java/com/mathworks/ci/actions/RunMatlabTestsAction.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.actions;
 
 /**
- * Copyright 2024-25, The MathWorks Inc.
+ * Copyright 2024-26, The MathWorks Inc.
  */
 
 import java.io.IOException;
@@ -29,6 +29,9 @@ public class RunMatlabTestsAction extends MatlabAction {
     }
 
     public void run() throws IOException, InterruptedException, MatlabExecutionException {
+        super.copyPluginsToTemp(this.params.getGenerateSummary());
+        super.setBuildEnvVars(this.params.getGenerateSummary());
+
         // Copy in genscript
         FilePath genScriptZip = runner.copyFileToTempFolder(
                 MatlabBuilderConstants.MATLAB_SCRIPT_GENERATOR,

--- a/src/main/java/com/mathworks/ci/freestyle/RunMatlabBuildBuilder.java
+++ b/src/main/java/com/mathworks/ci/freestyle/RunMatlabBuildBuilder.java
@@ -1,10 +1,11 @@
 package com.mathworks.ci.freestyle;
 
 /**
- * Copyright 2022-2024 The MathWorks, Inc.
+ * Copyright 2022-26 The MathWorks, Inc.
  */
 
 import java.io.IOException;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -39,6 +40,7 @@ public class RunMatlabBuildBuilder extends Builder implements SimpleBuildStep {
     private String tasks;
     private StartupOptions startupOptions;
     private BuildOptions buildOptions;
+    private Boolean generateSummary;
 
     private MatlabActionFactory factory;
 
@@ -67,6 +69,11 @@ public class RunMatlabBuildBuilder extends Builder implements SimpleBuildStep {
         this.buildOptions = buildOptions;
     }
 
+    @DataBoundSetter
+    public void setGenerateSummary(Boolean generateSummary) {
+        this.generateSummary = generateSummary;
+    }
+
     public String getTasks() {
         return this.tasks;
     }
@@ -89,6 +96,10 @@ public class RunMatlabBuildBuilder extends Builder implements SimpleBuildStep {
         return this.buildOptions == null
                 ? null
                 : this.buildOptions.getOptions();
+    }
+
+    public boolean getGenerateSummary() {
+        return this.generateSummary == null || this.generateSummary;
     }
 
     @Extension
@@ -139,7 +150,8 @@ public class RunMatlabBuildBuilder extends Builder implements SimpleBuildStep {
                 build, workspace, env, launcher, listener,
                 this.getStartupOptionsAsString(),
                 this.getTasks(),
-                this.getBuildOptionsAsString());
+                this.getBuildOptionsAsString(),
+                this.getGenerateSummary());
         RunMatlabBuildAction action = factory.createAction(params);
 
         try {
@@ -152,6 +164,8 @@ public class RunMatlabBuildBuilder extends Builder implements SimpleBuildStep {
     // Added for backwards compatibility:
     // Called when object is loaded from persistent data.
     protected Object readResolve() {
+        this.generateSummary = Optional.ofNullable(this.generateSummary).orElse(true);
+
         if (factory == null) {
             factory = new MatlabActionFactory();
         }

--- a/src/main/java/com/mathworks/ci/freestyle/RunMatlabCommandBuilder.java
+++ b/src/main/java/com/mathworks/ci/freestyle/RunMatlabCommandBuilder.java
@@ -1,13 +1,14 @@
 package com.mathworks.ci.freestyle;
 
 /**
- * Copyright 2019-2024 The MathWorks, Inc.
+ * Copyright 2019-26 The MathWorks, Inc.
  * 
  * Script builder used to run custom MATLAB commands or scripts.
  */
 
 import hudson.util.FormValidation;
 import java.io.IOException;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -44,6 +45,7 @@ public class RunMatlabCommandBuilder extends Builder implements SimpleBuildStep 
     // In use
     private String matlabCommand;
     private StartupOptions startupOptions;
+    private Boolean generateSummary;
 
     private MatlabActionFactory factory;
 
@@ -67,6 +69,11 @@ public class RunMatlabCommandBuilder extends Builder implements SimpleBuildStep 
         this.startupOptions = startupOptions;
     }
 
+    @DataBoundSetter
+    public void setGenerateSummary(Boolean generateSummary) {
+        this.generateSummary = generateSummary;
+    }
+
     public String getMatlabCommand() {
         return this.matlabCommand;
     }
@@ -79,6 +86,10 @@ public class RunMatlabCommandBuilder extends Builder implements SimpleBuildStep 
         return this.startupOptions == null
                 ? ""
                 : this.startupOptions.getOptions();
+    }
+
+    public boolean getGenerateSummary() {
+        return this.generateSummary == null || this.generateSummary;
     }
 
     @Extension
@@ -139,7 +150,8 @@ public class RunMatlabCommandBuilder extends Builder implements SimpleBuildStep 
                 build, workspace, env,
                 launcher, listener,
                 getStartupOptionsAsString(),
-                getMatlabCommand());
+                getMatlabCommand(),
+                getGenerateSummary());
         RunMatlabCommandAction action = factory.createAction(params);
 
         try {
@@ -152,6 +164,8 @@ public class RunMatlabCommandBuilder extends Builder implements SimpleBuildStep 
     // Added for backwards compatibility:
     // Called when object is loaded from persistent data.
     protected Object readResolve() {
+        this.generateSummary = Optional.ofNullable(this.generateSummary).orElse(true);
+
         if (factory == null) {
             factory = new MatlabActionFactory();
         }

--- a/src/main/java/com/mathworks/ci/freestyle/RunMatlabTestsBuilder.java
+++ b/src/main/java/com/mathworks/ci/freestyle/RunMatlabTestsBuilder.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.freestyle;
 
 /** 
- * Copyright 2019-2024 The MathWorks, Inc.  
+ * Copyright 2019-26 The MathWorks, Inc.  
  *  
  * MATLAB test run builder used to run all MATLAB & Simulink tests automatically and generate   
  * selected test artifacts. 
@@ -73,6 +73,7 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep {
     private String outputDetail = "default";
     private boolean useParallel = false;
     private boolean strict = false;
+    private Boolean generateSummary;
 
     private MatlabActionFactory factory;
 
@@ -170,6 +171,11 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep {
     @DataBoundSetter
     public void setStrict(boolean strict) {
         this.strict = strict;
+    }
+
+    @DataBoundSetter
+    public void setGenerateSummary(Boolean generateSummary) {
+        this.generateSummary = generateSummary;
     }
 
     public String getTapReportFilePath() {
@@ -297,6 +303,10 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep {
         return this.useParallel;
     }
 
+    public boolean getGenerateSummary() {
+        return this.generateSummary == null || this.generateSummary;
+    }
+
     public StartupOptions getStartupOptions() {
         return this.startupOptions;
     }
@@ -345,6 +355,8 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep {
         this.htmlModelCoverageArtifact = Optional.ofNullable(this.htmlModelCoverageArtifact)
                 .orElseGet(() -> this.getArtifactObject(htmlModelCoverageChkBx,
                         new HtmlModelCoverageArtifact("matlabTestArtifacts/htmlmodelcoverage")));
+
+        this.generateSummary = Optional.ofNullable(this.generateSummary).orElse(true);
 
         if (factory == null) {
             factory = new MatlabActionFactory();
@@ -469,6 +481,7 @@ public class RunMatlabTestsBuilder extends Builder implements SimpleBuildStep {
                 this.getOutputDetail(),
                 this.getUseParallel(),
                 this.getStrict(),
+                this.getGenerateSummary(),
                 this.getSourceFolderPaths(),
                 this.getSelectByFolderPaths());
         RunMatlabTestsAction action = factory.createAction(params);

--- a/src/main/java/com/mathworks/ci/parameters/BuildActionParameters.java
+++ b/src/main/java/com/mathworks/ci/parameters/BuildActionParameters.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.parameters;
 
 /**
- * Copyright 2024 The MathWorks, Inc.
+ * Copyright 2024-26 The MathWorks, Inc.
  */
 
 import java.io.IOException;
@@ -16,16 +16,17 @@ public class BuildActionParameters extends MatlabActionParameters {
     private String tasks;
     private String buildOptions;
 
-    public BuildActionParameters(StepContext context, String startupOpts, String tasks, String buildOpts)
-            throws IOException, InterruptedException {
-        super(context, startupOpts);
+    public BuildActionParameters(StepContext context, String startupOpts, String tasks, String buildOpts,
+            boolean generateSummary) throws IOException, InterruptedException {
+        super(context, startupOpts, generateSummary);
         this.tasks = tasks;
         this.buildOptions = buildOpts;
     }
 
     public BuildActionParameters(Run<?, ?> build, FilePath workspace, EnvVars env, Launcher launcher,
-            TaskListener listener, String startupOpts, String tasks, String buildOptions) {
-        super(build, workspace, env, launcher, listener, startupOpts);
+            TaskListener listener, String startupOpts, String tasks, String buildOptions,
+            boolean generateSummary) {
+        super(build, workspace, env, launcher, listener, startupOpts, generateSummary);
         this.tasks = tasks;
         this.buildOptions = buildOptions;
     }

--- a/src/main/java/com/mathworks/ci/parameters/CommandActionParameters.java
+++ b/src/main/java/com/mathworks/ci/parameters/CommandActionParameters.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.parameters;
 
 /**
- * Copyright 2024 The MathWorks, Inc.
+ * Copyright 2024-26 The MathWorks, Inc.
  */
 
 import java.io.IOException;
@@ -15,15 +15,15 @@ import org.jenkinsci.plugins.workflow.steps.StepContext;
 public class CommandActionParameters extends MatlabActionParameters {
     private String command;
 
-    public CommandActionParameters(StepContext context, String startupOpts, String command)
-            throws IOException, InterruptedException {
-        super(context, startupOpts);
+    public CommandActionParameters(StepContext context, String startupOpts, String command,
+            boolean generateSummary) throws IOException, InterruptedException {
+        super(context, startupOpts, generateSummary);
         this.command = command;
     }
 
     public CommandActionParameters(Run<?, ?> build, FilePath workspace, EnvVars env, Launcher launcher,
-            TaskListener listener, String startupOpts, String command) {
-        super(build, workspace, env, launcher, listener, startupOpts);
+            TaskListener listener, String startupOpts, String command, boolean generateSummary) {
+        super(build, workspace, env, launcher, listener, startupOpts, generateSummary);
         this.command = command;
     }
 

--- a/src/main/java/com/mathworks/ci/parameters/MatlabActionParameters.java
+++ b/src/main/java/com/mathworks/ci/parameters/MatlabActionParameters.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.parameters;
 
 /**
- * Copyright 2024 The MathWorks, Inc.
+ * Copyright 2024-26 The MathWorks, Inc.
  */
 
 import java.io.IOException;
@@ -20,24 +20,28 @@ public class MatlabActionParameters {
     private TaskListener listener;
 
     private String startupOptions;
+    private boolean generateSummary;
 
-    public MatlabActionParameters(StepContext context, String startupOpts) throws IOException, InterruptedException {
+    public MatlabActionParameters(StepContext context, String startupOpts, boolean generateSummary)
+            throws IOException, InterruptedException {
         this.build = context.get(Run.class);
         this.workspace = context.get(FilePath.class);
         this.env = context.get(EnvVars.class);
         this.launcher = context.get(Launcher.class);
         this.listener = context.get(TaskListener.class);
         this.startupOptions = startupOpts;
+        this.generateSummary = generateSummary;
     }
 
     public MatlabActionParameters(Run build, FilePath workspace, EnvVars env, Launcher launcher, TaskListener listener,
-            String startupOpts) {
+            String startupOpts, boolean generateSummary) {
         this.build = build;
         this.workspace = workspace;
         this.env = env;
         this.launcher = launcher;
         this.listener = listener;
         this.startupOptions = startupOpts;
+        this.generateSummary = generateSummary;
     }
 
     public Run<?, ?> getBuild() {
@@ -62,5 +66,9 @@ public class MatlabActionParameters {
 
     public String getStartupOptions() {
         return startupOptions;
+    }
+
+    public boolean getGenerateSummary() {
+        return generateSummary;
     }
 }

--- a/src/main/java/com/mathworks/ci/parameters/TestActionParameters.java
+++ b/src/main/java/com/mathworks/ci/parameters/TestActionParameters.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.parameters;
 
 /**
- * Copyright 2024 The MathWorks, Inc.
+ * Copyright 2024-26 The MathWorks, Inc.
  */
 
 import java.util.List;
@@ -36,10 +36,10 @@ public class TestActionParameters extends MatlabActionParameters {
             String testResultsPDF, String testResultsHTML, String testResultsTAP, String testResultsJUnit,
             String codeCoverageCobertura, String codeCoverageHTML, String testResultsSimulinkTest, String modelCoverageCobertura, String modelCoverageHTML,
             String selectByTag, String loggingLevel, String outputDetail,
-            boolean useParallel, boolean strict, List<String> sourceFolder,
-            List<String> selectByFolder)
+            boolean useParallel, boolean strict, boolean generateSummary,
+            List<String> sourceFolder, List<String> selectByFolder)
             throws IOException, InterruptedException {
-        super(context, startupOpts);
+        super(context, startupOpts, generateSummary);
         this.testResultsPDF = testResultsPDF;
         this.testResultsHTML = testResultsHTML;
         this.testResultsTAP = testResultsTAP;
@@ -63,9 +63,9 @@ public class TestActionParameters extends MatlabActionParameters {
             String testResultsPDF, String testResultsHTML, String testResultsTAP, String testResultsJUnit,
             String codeCoverageCobertura, String codeCoverageHTML, String testResultsSimulinkTest, String modelCoverageCobertura, String modelCoverageHTML,
             String selectByTag, String loggingLevel, String outputDetail,
-            boolean useParallel, boolean strict, List<String> sourceFolder,
-            List<String> selectByFolder) {
-        super(build, workspace, env, launcher, listener, startupOpts);
+            boolean useParallel, boolean strict, boolean generateSummary,
+            List<String> sourceFolder, List<String> selectByFolder) {
+        super(build, workspace, env, launcher, listener, startupOpts, generateSummary);
         this.testResultsPDF = testResultsPDF;
         this.testResultsHTML = testResultsHTML;
         this.testResultsTAP = testResultsTAP;

--- a/src/main/java/com/mathworks/ci/pipeline/MatlabBuildStepExecution.java
+++ b/src/main/java/com/mathworks/ci/pipeline/MatlabBuildStepExecution.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.pipeline;
 
 /**
- * Copyright 2022-2024 The MathWorks, Inc.
+ * Copyright 2022-26 The MathWorks, Inc.
  */
 
 import java.io.IOException;
@@ -39,7 +39,8 @@ public class MatlabBuildStepExecution extends SynchronousNonBlockingStepExecutio
                 getContext(),
                 step.getStartupOptions(),
                 step.getTasks(),
-                step.getBuildOptions());
+                step.getBuildOptions(),
+                step.getGenerateSummary());
 
         RunMatlabBuildAction action = factory.createAction(params);
         try {

--- a/src/main/java/com/mathworks/ci/pipeline/MatlabCommandStepExecution.java
+++ b/src/main/java/com/mathworks/ci/pipeline/MatlabCommandStepExecution.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.pipeline;
 
 /**
- * Copyright 2023-2024 The MathWorks, Inc.
+ * Copyright 2023-26 The MathWorks, Inc.
  */
 
 import java.io.IOException;
@@ -38,7 +38,8 @@ public class MatlabCommandStepExecution extends SynchronousNonBlockingStepExecut
         CommandActionParameters params = new CommandActionParameters(
                 getContext(),
                 step.getStartupOptions(),
-                step.getCommand());
+                step.getCommand(),
+                step.getGenerateSummary());
         RunMatlabCommandAction action = factory.createAction(params);
 
         try {

--- a/src/main/java/com/mathworks/ci/pipeline/MatlabRunTestsStepExecution.java
+++ b/src/main/java/com/mathworks/ci/pipeline/MatlabRunTestsStepExecution.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.pipeline;
 
 /**
- * Copyright 2020-2024 The MathWorks, Inc.
+ * Copyright 2020-26 The MathWorks, Inc.
  */
 
 import java.io.IOException;
@@ -54,6 +54,7 @@ public class MatlabRunTestsStepExecution extends SynchronousNonBlockingStepExecu
                 step.getOutputDetail(),
                 step.getUseParallel(),
                 step.getStrict(),
+                step.getGenerateSummary(),
                 step.getSourceFolder(),
                 step.getSelectByFolder());
         RunMatlabTestsAction action = factory.createAction(params);

--- a/src/main/java/com/mathworks/ci/pipeline/RunMatlabBuildStep.java
+++ b/src/main/java/com/mathworks/ci/pipeline/RunMatlabBuildStep.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.pipeline;
 
 /**
- * Copyright 2022-2024 The MathWorks, Inc.
+ * Copyright 2022-26 The MathWorks, Inc.
  */
 
 import java.io.Serializable;
@@ -30,6 +30,7 @@ public class RunMatlabBuildStep extends Step implements Serializable {
     private String tasks;
     private String startupOptions;
     private String buildOptions;
+    private boolean generateSummary = true;
 
     @DataBoundConstructor
     public RunMatlabBuildStep() {
@@ -48,6 +49,10 @@ public class RunMatlabBuildStep extends Step implements Serializable {
         return Util.fixNull(buildOptions);
     }
 
+    public boolean getGenerateSummary() {
+        return generateSummary;
+    }
+
     @DataBoundSetter
     public void setTasks(String tasks) {
         this.tasks = tasks;
@@ -61,6 +66,11 @@ public class RunMatlabBuildStep extends Step implements Serializable {
     @DataBoundSetter
     public void setBuildOptions(String buildOptions) {
         this.buildOptions = buildOptions;
+    }
+
+    @DataBoundSetter
+    public void setGenerateSummary(boolean generateSummary) {
+        this.generateSummary = generateSummary;
     }
 
     @Override

--- a/src/main/java/com/mathworks/ci/pipeline/RunMatlabCommandStep.java
+++ b/src/main/java/com/mathworks/ci/pipeline/RunMatlabCommandStep.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.pipeline;
 
 /**
- * Copyright 2020-2024 The MathWorks, Inc.
+ * Copyright 2020-26 The MathWorks, Inc.
  */
 
 import java.io.Serializable;
@@ -29,6 +29,7 @@ public class RunMatlabCommandStep extends Step implements Serializable {
 
     private String command;
     private String startupOptions = "";
+    private boolean generateSummary = true;
 
     @DataBoundConstructor
     public RunMatlabCommandStep(String command) {
@@ -46,6 +47,15 @@ public class RunMatlabCommandStep extends Step implements Serializable {
 
     public String getStartupOptions() {
         return Util.fixNull(this.startupOptions);
+    }
+
+    @DataBoundSetter
+    public void setGenerateSummary(boolean generateSummary) {
+        this.generateSummary = generateSummary;
+    }
+
+    public boolean getGenerateSummary() {
+        return generateSummary;
     }
 
     @Override

--- a/src/main/java/com/mathworks/ci/pipeline/RunMatlabTestsStep.java
+++ b/src/main/java/com/mathworks/ci/pipeline/RunMatlabTestsStep.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.pipeline;
 
 /**
- * Copyright 2020-2024 The MathWorks, Inc.
+ * Copyright 2020-26 The MathWorks, Inc.
  */
 
 import java.io.Serializable;
@@ -46,6 +46,7 @@ public class RunMatlabTestsStep extends Step implements Serializable {
     private List<String> selectByFolder;
 
     private String startupOptions;
+    private boolean generateSummary = true;
 
     @DataBoundConstructor
     public RunMatlabTestsStep() {
@@ -203,6 +204,15 @@ public class RunMatlabTestsStep extends Step implements Serializable {
     @DataBoundSetter
     public void setStartupOptions(String startupOptions) {
         this.startupOptions = startupOptions;
+    }
+
+    public boolean getGenerateSummary() {
+        return generateSummary;
+    }
+
+    @DataBoundSetter
+    public void setGenerateSummary(boolean generateSummary) {
+        this.generateSummary = generateSummary;
     }
 
     @Override

--- a/src/main/resources/+ciplugins/+jenkins/getDefaultPlugins.m
+++ b/src/main/resources/+ciplugins/+jenkins/getDefaultPlugins.m
@@ -11,7 +11,7 @@ plugins = [ ...
     ciplugins.jenkins.TaskRunProgressPlugin() ...
 ];
 
-if strcmp(getenv("MW_GENERATE_SUMMARY"), "true")
+if strcmp(getenv("MW_INPUT_GENERATE_SUMMARY"), "true")
     if isMATLABReleaseOlderThan("R2026a")
         reportPlugin = ciplugins.jenkins.BuildReportPlugin();
     else

--- a/src/main/resources/+ciplugins/+jenkins/getDefaultPlugins.m
+++ b/src/main/resources/+ciplugins/+jenkins/getDefaultPlugins.m
@@ -1,20 +1,22 @@
 function plugins = getDefaultPlugins(pluginProviderData)
 %
 
-%   Copyright 2024-2025 The MathWorks, Inc.
+%   Copyright 2024-26 The MathWorks, Inc.
 arguments
     pluginProviderData (1,1) struct = struct();
 end
 
-if isMATLABReleaseOlderThan("R2026a")
-    reportPlugin = ciplugins.jenkins.BuildReportPlugin();
-else
-    reportPlugin = ciplugins.jenkins.ParallelizableBuildReportPlugin();
-end
-
 plugins = [ ...
     matlab.buildtool.internal.getFactoryDefaultPlugins(pluginProviderData) ...
-    reportPlugin ...
     ciplugins.jenkins.TaskRunProgressPlugin() ...
 ];
+
+if strcmp(getenv("MW_GENERATE_SUMMARY"), "true")
+    if isMATLABReleaseOlderThan("R2026a")
+        reportPlugin = ciplugins.jenkins.BuildReportPlugin();
+    else
+        reportPlugin = ciplugins.jenkins.ParallelizableBuildReportPlugin();
+    end
+    plugins = [plugins reportPlugin];
+end
 end

--- a/src/main/resources/com/mathworks/ci/freestyle/RunMatlabBuildBuilder/config.jelly
+++ b/src/main/resources/com/mathworks/ci/freestyle/RunMatlabBuildBuilder/config.jelly
@@ -1,16 +1,20 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    
-	  <f:entry title="Tasks" field="tasks">
-	        <f:textbox/>
-	  </f:entry> 
+      
+      <f:block>
+            <f:entry title="Tasks" field="tasks">
+                  <f:textbox/>
+            </f:entry> 
 
-      <f:optionalProperty field="startupOptions" title="Startup options" />
-      
-      <f:entry field="generateSummary" title="Generate results summary" checked="${instance.generateSummary}">
-          <f:checkbox default="true"/>
-      </f:entry>
-      
-      <f:optionalProperty field="buildOptions" title="Build options" />
+            <f:optionalProperty field="startupOptions" title="Startup options" />
+            
+            <f:entry field="generateSummary" title="Generate results summary" checked="${instance.generateSummary}">
+            <f:checkbox default="true"/>
+            </f:entry>
+      </f:block>
+
+      <f:section title="Customize Build Run">
+            <f:optionalProperty field="buildOptions" title="Build options" />
+      </f:section>
 
 </j:jelly>

--- a/src/main/resources/com/mathworks/ci/freestyle/RunMatlabBuildBuilder/config.jelly
+++ b/src/main/resources/com/mathworks/ci/freestyle/RunMatlabBuildBuilder/config.jelly
@@ -8,7 +8,7 @@
 
             <f:optionalProperty field="startupOptions" title="Startup options" />
             
-            <f:entry field="generateSummary" title="Generate results summary" checked="${instance.generateSummary}">
+            <f:entry field="generateSummary" title="Generate summary" checked="${instance.generateSummary}">
             <f:checkbox default="true"/>
             </f:entry>
       </f:block>

--- a/src/main/resources/com/mathworks/ci/freestyle/RunMatlabBuildBuilder/config.jelly
+++ b/src/main/resources/com/mathworks/ci/freestyle/RunMatlabBuildBuilder/config.jelly
@@ -6,7 +6,11 @@
 	  </f:entry> 
 
       <f:optionalProperty field="startupOptions" title="Startup options" />
-	  
+      
+      <f:entry field="generateSummary" title="Generate results summary" checked="${instance.generateSummary}">
+          <f:checkbox default="true"/>
+      </f:entry>
+      
       <f:optionalProperty field="buildOptions" title="Build options" />
 
 </j:jelly>

--- a/src/main/resources/com/mathworks/ci/freestyle/RunMatlabBuildBuilder/help-generateSummary.html
+++ b/src/main/resources/com/mathworks/ci/freestyle/RunMatlabBuildBuilder/help-generateSummary.html
@@ -1,0 +1,3 @@
+<div>
+    Whether to generate result summaries for the build.
+</div>

--- a/src/main/resources/com/mathworks/ci/freestyle/RunMatlabBuildBuilder/help-generateSummary.html
+++ b/src/main/resources/com/mathworks/ci/freestyle/RunMatlabBuildBuilder/help-generateSummary.html
@@ -1,3 +1,3 @@
 <div>
-    Whether to generate result summaries for the build.
+    Option to generate a summary for the Jenkins build summary.
 </div>

--- a/src/main/resources/com/mathworks/ci/freestyle/RunMatlabCommandBuilder/config.jelly
+++ b/src/main/resources/com/mathworks/ci/freestyle/RunMatlabCommandBuilder/config.jelly
@@ -7,4 +7,8 @@
 
       <f:optionalProperty field="startupOptions" title="Startup options" />
 
+      <f:entry field="generateSummary" title="Generate results summary" checked="${instance.generateSummary}">
+          <f:checkbox default="true"/>
+      </f:entry>
+
 </j:jelly>

--- a/src/main/resources/com/mathworks/ci/freestyle/RunMatlabCommandBuilder/config.jelly
+++ b/src/main/resources/com/mathworks/ci/freestyle/RunMatlabCommandBuilder/config.jelly
@@ -7,7 +7,7 @@
 
       <f:optionalProperty field="startupOptions" title="Startup options" />
 
-      <f:entry field="generateSummary" title="Generate results summary" checked="${instance.generateSummary}">
+      <f:entry field="generateSummary" title="Generate summary" checked="${instance.generateSummary}">
           <f:checkbox default="true"/>
       </f:entry>
 

--- a/src/main/resources/com/mathworks/ci/freestyle/RunMatlabCommandBuilder/help-generateSummary.html
+++ b/src/main/resources/com/mathworks/ci/freestyle/RunMatlabCommandBuilder/help-generateSummary.html
@@ -1,0 +1,3 @@
+<div>
+    Whether to generate result summaries for the build.
+</div>

--- a/src/main/resources/com/mathworks/ci/freestyle/RunMatlabCommandBuilder/help-generateSummary.html
+++ b/src/main/resources/com/mathworks/ci/freestyle/RunMatlabCommandBuilder/help-generateSummary.html
@@ -1,3 +1,3 @@
 <div>
-    Whether to generate result summaries for the build.
+    Option to generate a summary for the Jenkins build summary.
 </div>

--- a/src/main/resources/com/mathworks/ci/freestyle/RunMatlabTestsBuilder/config.jelly
+++ b/src/main/resources/com/mathworks/ci/freestyle/RunMatlabTestsBuilder/config.jelly
@@ -1,8 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-    <f:block> 
-        <br></br>
+    <f:block>
         <f:optionalProperty field="sourceFolder" title="Source folder" />
         <f:optionalProperty field="startupOptions" title="Startup options" />
         <f:entry field="generateSummary" title="Generate results summary" checked="${instance.generateSummary}">
@@ -10,16 +9,12 @@
         </f:entry>
     </f:block>
 
-    <br></br>
-
     <f:section title="Filter Tests">
         <f:block>
             <f:optionalProperty field="selectByFolder" title="By folder name" />
-            <br></br>
             <f:optionalProperty field="selectByTag" title="By tag" /> 
         </f:block>
     </f:section>
-    <br></br>
 
     <f:section title="Customize Test Run">
         <f:block>
@@ -41,8 +36,6 @@
             </f:entry>
         </f:block>
     </f:section>
-
-    <br></br>
 
     <f:section title="Generate Test Artifacts">
         <f:block>
@@ -77,8 +70,6 @@
             </f:optionalBlock>
         </f:block>
     </f:section>
-    
-    <br></br>
 
     <f:section title="Generate Coverage Artifacts">
         <f:block>

--- a/src/main/resources/com/mathworks/ci/freestyle/RunMatlabTestsBuilder/config.jelly
+++ b/src/main/resources/com/mathworks/ci/freestyle/RunMatlabTestsBuilder/config.jelly
@@ -5,6 +5,9 @@
         <br></br>
         <f:optionalProperty field="sourceFolder" title="Source folder" />
         <f:optionalProperty field="startupOptions" title="Startup options" />
+        <f:entry field="generateSummary" title="Generate results summary" checked="${instance.generateSummary}">
+            <f:checkbox default="true"/>
+        </f:entry>
     </f:block>
 
     <br></br>
@@ -21,8 +24,8 @@
     <f:section title="Customize Test Run">
         <f:block>
             <f:entry field="strict" title="Strict " checked="${instance.strict}">
-                <f:checkbox/> 
-            </f:entry> 
+                <f:checkbox/>
+            </f:entry>
             <f:entry field="useParallel" title="Use parallel " checked="${instance.useParallel}">
                 <f:checkbox/>
             </f:entry>

--- a/src/main/resources/com/mathworks/ci/freestyle/RunMatlabTestsBuilder/config.jelly
+++ b/src/main/resources/com/mathworks/ci/freestyle/RunMatlabTestsBuilder/config.jelly
@@ -4,7 +4,7 @@
     <f:block>
         <f:optionalProperty field="sourceFolder" title="Source folder" />
         <f:optionalProperty field="startupOptions" title="Startup options" />
-        <f:entry field="generateSummary" title="Generate results summary" checked="${instance.generateSummary}">
+        <f:entry field="generateSummary" title="Generate summary" checked="${instance.generateSummary}">
             <f:checkbox default="true"/>
         </f:entry>
     </f:block>

--- a/src/main/resources/com/mathworks/ci/freestyle/RunMatlabTestsBuilder/help-generateSummary.html
+++ b/src/main/resources/com/mathworks/ci/freestyle/RunMatlabTestsBuilder/help-generateSummary.html
@@ -1,0 +1,3 @@
+<div>
+    Whether to generate test results summary for the build.
+</div>

--- a/src/main/resources/com/mathworks/ci/freestyle/RunMatlabTestsBuilder/help-generateSummary.html
+++ b/src/main/resources/com/mathworks/ci/freestyle/RunMatlabTestsBuilder/help-generateSummary.html
@@ -1,3 +1,3 @@
 <div>
-    Whether to generate test results summary for the build.
+    Option to generate a summary for the Jenkins build summary.
 </div>

--- a/src/main/resources/com/mathworks/ci/pipeline/RunMatlabBuildStep/config.jelly
+++ b/src/main/resources/com/mathworks/ci/pipeline/RunMatlabBuildStep/config.jelly
@@ -13,4 +13,8 @@
             <f:textbox/>
       </f:entry>
 
+      <f:entry field="generateSummary" title="generateSummary: ">
+        <f:checkbox default="true"/>
+      </f:entry>
+
 </j:jelly>

--- a/src/main/resources/com/mathworks/ci/pipeline/RunMatlabCommandStep/config.jelly
+++ b/src/main/resources/com/mathworks/ci/pipeline/RunMatlabCommandStep/config.jelly
@@ -7,6 +7,10 @@
 
 	  <f:entry field="startupOptions" title="startupOptions: ">
 	        <f:textbox/>
-	  </f:entry> 
+	  </f:entry>
+
+      <f:entry field="generateSummary" title="generateSummary: ">
+        <f:checkbox default="true"/>
+      </f:entry>
 
 </j:jelly>

--- a/src/main/resources/com/mathworks/ci/pipeline/RunMatlabTestsStep/config.jelly
+++ b/src/main/resources/com/mathworks/ci/pipeline/RunMatlabTestsStep/config.jelly
@@ -70,4 +70,8 @@
         <f:textbox/>
       </f:entry>
 
+      <f:entry field="generateSummary" title="generateSummary: ">
+        <f:checkbox default="true"/>
+      </f:entry>
+
 </j:jelly>

--- a/src/test/java/com/mathworks/ci/actions/MatlabActionTest.java
+++ b/src/test/java/com/mathworks/ci/actions/MatlabActionTest.java
@@ -192,7 +192,7 @@ public class MatlabActionTest {
 
         MatlabAction matlabAction = new MatlabAction(localRunner, localAnnotator);
         matlabAction.setBuildEnvVars(true);
-        verify(localRunner).addEnvironmentVariable("MW_GENERATE_SUMMARY", "true");
+        verify(localRunner).addEnvironmentVariable("MW_INPUT_GENERATE_SUMMARY", "true");
 
         MatlabCommandRunner localRunner2 = mock(MatlabCommandRunner.class);
         FilePath localTempFolder2 = mock(FilePath.class);
@@ -200,7 +200,7 @@ public class MatlabActionTest {
 
         MatlabAction matlabAction2 = new MatlabAction(localRunner2, localAnnotator);
         matlabAction2.setBuildEnvVars(false);
-        verify(localRunner2).addEnvironmentVariable("MW_GENERATE_SUMMARY", "false");
+        verify(localRunner2).addEnvironmentVariable("MW_INPUT_GENERATE_SUMMARY", "false");
     }
 
     @Test

--- a/src/test/java/com/mathworks/ci/actions/MatlabActionTest.java
+++ b/src/test/java/com/mathworks/ci/actions/MatlabActionTest.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.actions;
 
 /**
- * Copyright 2024, The MathWorks Inc.
+ * Copyright 2024-26, The MathWorks Inc.
  */
 
 import java.io.File;
@@ -18,7 +18,7 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import hudson.FilePath;
@@ -68,6 +68,7 @@ public class MatlabActionTest {
             when(listener.getLogger()).thenReturn(out);
 
             when(params.getBuild()).thenReturn(build);
+            when(params.getGenerateSummary()).thenReturn(true);
         }
     }
 
@@ -80,11 +81,11 @@ public class MatlabActionTest {
         inOrder.verify(runner)
                 .copyFileToTempFolder(MatlabBuilderConstants.DEFAULT_PLUGIN, MatlabBuilderConstants.DEFAULT_PLUGIN);
         inOrder.verify(runner)
-                .copyFileToTempFolder(MatlabBuilderConstants.BUILD_REPORT_PLUGIN,
-                        MatlabBuilderConstants.BUILD_REPORT_PLUGIN);
-        inOrder.verify(runner)
                 .copyFileToTempFolder(MatlabBuilderConstants.TASK_RUN_PROGRESS_PLUGIN,
                         MatlabBuilderConstants.TASK_RUN_PROGRESS_PLUGIN);
+        inOrder.verify(runner)
+                .copyFileToTempFolder(MatlabBuilderConstants.BUILD_REPORT_PLUGIN,
+                        MatlabBuilderConstants.BUILD_REPORT_PLUGIN);
     }
 
     @Test
@@ -132,5 +133,89 @@ public class MatlabActionTest {
         action.run();
 
         verify(runner).removeTempFolder();
+    }
+
+    @Test
+    public void shouldOnlyCopyNonVisualizationPluginsWhenGenerateSummaryFalse()
+            throws IOException, InterruptedException {
+        MatlabCommandRunner localRunner = mock(MatlabCommandRunner.class);
+        BuildConsoleAnnotator localAnnotator = mock(BuildConsoleAnnotator.class);
+
+        MatlabAction matlabAction = new MatlabAction(localRunner, localAnnotator);
+        matlabAction.copyPluginsToTemp(false);
+
+        verify(localRunner).copyFileToTempFolder(
+                MatlabBuilderConstants.DEFAULT_PLUGIN, MatlabBuilderConstants.DEFAULT_PLUGIN);
+        verify(localRunner).copyFileToTempFolder(
+                MatlabBuilderConstants.TASK_RUN_PROGRESS_PLUGIN, MatlabBuilderConstants.TASK_RUN_PROGRESS_PLUGIN);
+
+        verify(localRunner, never()).copyFileToTempFolder(
+                MatlabBuilderConstants.BUILD_REPORT_PLUGIN, MatlabBuilderConstants.BUILD_REPORT_PLUGIN);
+        verify(localRunner, never()).copyFileToTempFolder(
+                MatlabBuilderConstants.PAR_BUILD_REPORT_PLUGIN, MatlabBuilderConstants.PAR_BUILD_REPORT_PLUGIN);
+        verify(localRunner, never()).copyFileToTempFolder(
+                MatlabBuilderConstants.TEST_RESULTS_VIEW_PLUGIN, MatlabBuilderConstants.TEST_RESULTS_VIEW_PLUGIN);
+        verify(localRunner, never()).copyFileToTempFolder(
+                MatlabBuilderConstants.TEST_RESULTS_VIEW_PLUGIN_SERVICE, MatlabBuilderConstants.TEST_RESULTS_VIEW_PLUGIN_SERVICE);
+    }
+
+    @Test
+    public void shouldCopyAllPluginsWhenGenerateSummaryTrue()
+            throws IOException, InterruptedException {
+        MatlabCommandRunner localRunner = mock(MatlabCommandRunner.class);
+        BuildConsoleAnnotator localAnnotator = mock(BuildConsoleAnnotator.class);
+
+        MatlabAction matlabAction = new MatlabAction(localRunner, localAnnotator);
+        matlabAction.copyPluginsToTemp(true);
+
+        verify(localRunner).copyFileToTempFolder(
+                MatlabBuilderConstants.DEFAULT_PLUGIN, MatlabBuilderConstants.DEFAULT_PLUGIN);
+        verify(localRunner).copyFileToTempFolder(
+                MatlabBuilderConstants.TASK_RUN_PROGRESS_PLUGIN, MatlabBuilderConstants.TASK_RUN_PROGRESS_PLUGIN);
+        verify(localRunner).copyFileToTempFolder(
+                MatlabBuilderConstants.BUILD_REPORT_PLUGIN, MatlabBuilderConstants.BUILD_REPORT_PLUGIN);
+        verify(localRunner).copyFileToTempFolder(
+                MatlabBuilderConstants.PAR_BUILD_REPORT_PLUGIN, MatlabBuilderConstants.PAR_BUILD_REPORT_PLUGIN);
+        verify(localRunner).copyFileToTempFolder(
+                MatlabBuilderConstants.TEST_RESULTS_VIEW_PLUGIN, MatlabBuilderConstants.TEST_RESULTS_VIEW_PLUGIN);
+        verify(localRunner).copyFileToTempFolder(
+                MatlabBuilderConstants.TEST_RESULTS_VIEW_PLUGIN_SERVICE, MatlabBuilderConstants.TEST_RESULTS_VIEW_PLUGIN_SERVICE);
+    }
+
+    @Test
+    public void shouldSetGenerateSummaryEnvVar()
+            throws IOException, InterruptedException {
+        MatlabCommandRunner localRunner = mock(MatlabCommandRunner.class);
+        BuildConsoleAnnotator localAnnotator = mock(BuildConsoleAnnotator.class);
+        FilePath localTempFolder = mock(FilePath.class);
+        when(localRunner.getTempFolder()).thenReturn(localTempFolder);
+
+        MatlabAction matlabAction = new MatlabAction(localRunner, localAnnotator);
+        matlabAction.setBuildEnvVars(true);
+        verify(localRunner).addEnvironmentVariable("MW_GENERATE_SUMMARY", "true");
+
+        MatlabCommandRunner localRunner2 = mock(MatlabCommandRunner.class);
+        FilePath localTempFolder2 = mock(FilePath.class);
+        when(localRunner2.getTempFolder()).thenReturn(localTempFolder2);
+
+        MatlabAction matlabAction2 = new MatlabAction(localRunner2, localAnnotator);
+        matlabAction2.setBuildEnvVars(false);
+        verify(localRunner2).addEnvironmentVariable("MW_GENERATE_SUMMARY", "false");
+    }
+
+    @Test
+    public void shouldAlwaysSetDefaultPluginsOverrideEnvVar()
+            throws IOException, InterruptedException {
+        MatlabCommandRunner localRunner = mock(MatlabCommandRunner.class);
+        BuildConsoleAnnotator localAnnotator = mock(BuildConsoleAnnotator.class);
+        FilePath localTempFolder = mock(FilePath.class);
+        when(localRunner.getTempFolder()).thenReturn(localTempFolder);
+
+        MatlabAction matlabAction = new MatlabAction(localRunner, localAnnotator);
+        matlabAction.setBuildEnvVars(false);
+
+        verify(localRunner).addEnvironmentVariable(
+                "MW_MATLAB_BUILDTOOL_DEFAULT_PLUGINS_FCN_OVERRIDE",
+                "ciplugins.jenkins.getDefaultPlugins");
     }
 }

--- a/src/test/java/com/mathworks/ci/freestyle/RunMatlabBuildBuilderUnitTest.java
+++ b/src/test/java/com/mathworks/ci/freestyle/RunMatlabBuildBuilderUnitTest.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.freestyle;
 
 /**
- * Copyright 2024, The MathWorks Inc.
+ * Copyright 2024-26, The MathWorks Inc.
  */
 
 import java.io.IOException;
@@ -68,6 +68,7 @@ public class RunMatlabBuildBuilderUnitTest {
         assertEquals("", actual.getStartupOptions());
         assertEquals(null, actual.getTasks());
         assertEquals(null, actual.getBuildOptions());
+        assertEquals(true, actual.getGenerateSummary());
         verify(action).run();
     }
 
@@ -77,6 +78,7 @@ public class RunMatlabBuildBuilderUnitTest {
         builder.setTasks("laundry sweeping");
         builder.setBuildOptions(new BuildOptions("-continueOnFailure -skip laundry"));
         builder.setStartupOptions(new StartupOptions("-nojvm -logfile mylog"));
+        builder.setGenerateSummary(false);
 
         builder.perform(build, workspace, launcher, listener);
 
@@ -88,6 +90,7 @@ public class RunMatlabBuildBuilderUnitTest {
         assertEquals("-nojvm -logfile mylog", actual.getStartupOptions());
         assertEquals("laundry sweeping", actual.getTasks());
         assertEquals("-continueOnFailure -skip laundry", actual.getBuildOptions());
+        assertEquals(false, actual.getGenerateSummary());
         verify(action).run();
     }
 

--- a/src/test/java/com/mathworks/ci/freestyle/RunMatlabCommandBuilderUnitTest.java
+++ b/src/test/java/com/mathworks/ci/freestyle/RunMatlabCommandBuilderUnitTest.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.freestyle;
 
 /**
- * Copyright 2024, The MathWorks Inc.
+ * Copyright 2024-26, The MathWorks Inc.
  */
 
 import java.io.IOException;
@@ -66,6 +66,7 @@ public class RunMatlabCommandBuilderUnitTest {
 
         assertEquals("", actual.getStartupOptions());
         assertEquals(null, actual.getCommand());
+        assertEquals(true, actual.getGenerateSummary());
         verify(action).run();
     }
 
@@ -74,6 +75,7 @@ public class RunMatlabCommandBuilderUnitTest {
         RunMatlabCommandBuilder builder = new RunMatlabCommandBuilder(factory);
         builder.setMatlabCommand("SHAKE");
         builder.setStartupOptions(new StartupOptions("-nojvm -logfile mylog"));
+        builder.setGenerateSummary(false);
 
         builder.perform(build, workspace, launcher, listener);
 
@@ -84,6 +86,7 @@ public class RunMatlabCommandBuilderUnitTest {
 
         assertEquals("-nojvm -logfile mylog", actual.getStartupOptions());
         assertEquals("SHAKE", actual.getCommand());
+        assertEquals(false, actual.getGenerateSummary());
         verify(action).run();
     }
 

--- a/src/test/java/com/mathworks/ci/freestyle/RunMatlabTestsBuilderUnitTest.java
+++ b/src/test/java/com/mathworks/ci/freestyle/RunMatlabTestsBuilderUnitTest.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.freestyle;
 
 /**
- * Copyright 2024, The MathWorks Inc.
+ * Copyright 2024-26, The MathWorks Inc.
  */
 
 import java.io.IOException;
@@ -80,6 +80,7 @@ public class RunMatlabTestsBuilderUnitTest {
                 assertEquals(null, actual.getOutputDetail());
                 assertEquals("false", actual.getUseParallel());
                 assertEquals("false", actual.getStrict());
+                assertEquals(true, actual.getGenerateSummary());
                 assertEquals(null, actual.getSourceFolder());
                 assertEquals(null, actual.getSelectByFolder());
                 verify(action).run();
@@ -126,6 +127,7 @@ public class RunMatlabTestsBuilderUnitTest {
                 builder.setOutputDetail("Concise");
                 builder.setUseParallel(true);
                 builder.setStrict(true);
+                builder.setGenerateSummary(false);
 
                 builder.perform(build, workspace, launcher, listener);
 
@@ -149,6 +151,7 @@ public class RunMatlabTestsBuilderUnitTest {
                 assertEquals("Concise", actual.getOutputDetail());
                 assertEquals("true", actual.getUseParallel());
                 assertEquals("true", actual.getStrict());
+                assertEquals(false, actual.getGenerateSummary());
                 assertEquals(2, actual.getSourceFolder().size());
                 assertEquals(2, actual.getSelectByFolder().size());
                 verify(action).run();

--- a/src/test/java/com/mathworks/ci/pipeline/MatlabBuildStepExecutionUnitTest.java
+++ b/src/test/java/com/mathworks/ci/pipeline/MatlabBuildStepExecutionUnitTest.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.pipeline;
 
 /**
- * Copyright 2024, The MathWorks Inc.
+ * Copyright 2024-26, The MathWorks Inc.
  */
 
 import java.io.IOException;
@@ -51,6 +51,7 @@ public class MatlabBuildStepExecutionUnitTest {
         assertEquals("", params.getStartupOptions());
         assertEquals("", params.getTasks());
         assertEquals("", params.getBuildOptions());
+        assertEquals(true, params.getGenerateSummary());
 
         verify(action).run();
     }
@@ -62,6 +63,7 @@ public class MatlabBuildStepExecutionUnitTest {
         step.setStartupOptions("-nojvm -logfile file");
         step.setTasks("vacuum bills");
         step.setBuildOptions("-continueOnFailure");
+        step.setGenerateSummary(false);
 
         MatlabBuildStepExecution ex = new MatlabBuildStepExecution(factory, context, step);
 
@@ -75,6 +77,7 @@ public class MatlabBuildStepExecutionUnitTest {
         assertEquals("-nojvm -logfile file", params.getStartupOptions());
         assertEquals("vacuum bills", params.getTasks());
         assertEquals("-continueOnFailure", params.getBuildOptions());
+        assertEquals(false, params.getGenerateSummary());
 
         verify(action).run();
     }

--- a/src/test/java/com/mathworks/ci/pipeline/MatlabCommandStepExecutionUnitTest.java
+++ b/src/test/java/com/mathworks/ci/pipeline/MatlabCommandStepExecutionUnitTest.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.pipeline;
 
 /**
- * Copyright 2024, The MathWorks Inc.
+ * Copyright 2024-26, The MathWorks Inc.
  */
 
 import java.io.IOException;
@@ -52,6 +52,7 @@ public class MatlabCommandStepExecutionUnitTest {
         CommandActionParameters params = captor.getValue();
         assertEquals("", params.getStartupOptions());
         assertEquals(null, params.getCommand());
+        assertEquals(true, params.getGenerateSummary());
 
         verify(action).run();
     }
@@ -61,6 +62,7 @@ public class MatlabCommandStepExecutionUnitTest {
             throws Exception, IOException, InterruptedException, MatlabExecutionException {
         RunMatlabCommandStep step = new RunMatlabCommandStep("mycommand");
         step.setStartupOptions("-nojvm -logfile file");
+        step.setGenerateSummary(false);
 
         MatlabCommandStepExecution ex = new MatlabCommandStepExecution(factory, context, step);
 
@@ -72,6 +74,7 @@ public class MatlabCommandStepExecutionUnitTest {
         CommandActionParameters params = captor.getValue();
         assertEquals("-nojvm -logfile file", params.getStartupOptions());
         assertEquals("mycommand", params.getCommand());
+        assertEquals(false, params.getGenerateSummary());
 
         verify(action).run();
     }

--- a/src/test/java/com/mathworks/ci/pipeline/MatlabRunTestsStepExecutionUnitTest.java
+++ b/src/test/java/com/mathworks/ci/pipeline/MatlabRunTestsStepExecutionUnitTest.java
@@ -1,7 +1,7 @@
 package com.mathworks.ci.pipeline;
 
 /**
- * Copyright 2024, The MathWorks Inc.
+ * Copyright 2024-26, The MathWorks Inc.
  */
 
 import java.io.IOException;
@@ -64,6 +64,7 @@ public class MatlabRunTestsStepExecutionUnitTest {
         assertEquals(null, params.getOutputDetail());
         assertEquals("false", params.getUseParallel());
         assertEquals("false", params.getStrict());
+        assertEquals(true, params.getGenerateSummary());
         assertEquals(null, params.getSourceFolder());
         assertEquals(null, params.getSelectByFolder());
 
@@ -89,6 +90,7 @@ public class MatlabRunTestsStepExecutionUnitTest {
         step.setOutputDetail("Concise");
         step.setUseParallel(true);
         step.setStrict(true);
+        step.setGenerateSummary(false);
 
         ArrayList<String> folders = new ArrayList<String>();
         folders.add("src");
@@ -120,6 +122,7 @@ public class MatlabRunTestsStepExecutionUnitTest {
         assertEquals("Concise", params.getOutputDetail());
         assertEquals("true", params.getUseParallel());
         assertEquals("true", params.getStrict());
+        assertEquals(false, params.getGenerateSummary());
         assertEquals(folders, params.getSourceFolder());
         assertEquals(folders, params.getSelectByFolder());
 


### PR DESCRIPTION
### Summary

  - Add a `generateSummary` option (default: `true`) to all three MATLAB steps — Run MATLAB Build, Run MATLAB Command, and Run MATLAB Tests — allowing users to opt out of result summary generation
  - Modify `getDefaultPlugins.m` to conditionally include the `BuildReportPlugin` based on the `MW_INPUT_GENERATE_SUMMARY` environment variable

### Backward Compatibility

  - Freestyle projects: Uses `Boolean` wrapper type with `readResolve()` to default existing saved configs to `true`
  - Pipeline steps: Uses `boolean` primitive with field initializer as `true`

### How it looks in Jenkins UI
For Run MATLAB Command step:
<img width="454" height="348" alt="Screenshot 2026-05-26 152631" src="https://github.com/user-attachments/assets/3056bf9c-686d-4363-b988-48cda0ba56a9" />
For Run MATLAB Tests step:
<img width="504" height="277" alt="Screenshot 2026-05-26 152604" src="https://github.com/user-attachments/assets/f995c29f-becd-4bac-aeb5-2e2610143747" />
For Run MATLAB Build step (also added a new "Customize Build Run" section below):
<img width="498" height="460" alt="Screenshot 2026-05-26 152644" src="https://github.com/user-attachments/assets/6d3073b7-7afd-4d76-877f-043879ff31e2" />
