### PR TITLE
Remove MATLAB Test license check

### DIFF
--- a/src/main/resources/+ciplugins/+jenkins/TestResultsViewPlugin.m
+++ b/src/main/resources/+ciplugins/+jenkins/TestResultsViewPlugin.m
@@ -3,9 +3,6 @@ classdef TestResultsViewPlugin < matlab.unittest.plugins.TestRunnerPlugin
     
     methods (Access=protected)
         function reportFinalizedSuite(plugin, pluginData)
-            % Checkout MATLAB Test license
-            license('checkout', 'matlab_test');
-
             testDetails = struct([]);
             for idx = 1:numel(pluginData.TestResult)
                 testDetails(idx).TestResult.Duration = pluginData.TestResult(idx).Duration;

--- a/src/main/resources/+matlab/+unittest/+internal/+services/+plugins/TestResultsViewPluginService.m
+++ b/src/main/resources/+matlab/+unittest/+internal/+services/+plugins/TestResultsViewPluginService.m
@@ -3,12 +3,7 @@ classdef TestResultsViewPluginService < matlab.buildtool.internal.services.ciplu
 
     methods
         function plugins = providePlugins(~, ~)
-            % Check if MATLAB Test license is available
-            if license('test', 'matlab_test')
-                plugins = ciplugins.jenkins.TestResultsViewPlugin();
-            else
-                plugins = matlab.unittest.plugins.TestRunnerPlugin.empty(1,0);
-            end
+            plugins = ciplugins.jenkins.TestResultsViewPlugin();
         end
     end
 end


### PR DESCRIPTION
### Summary

- Remove MATLAB Test license check and checkout, so the test results view feature is provided unconditionally