### PR TITLE
Migrate from Commons Lang 2 to Commons Lang 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,10 @@
 			<artifactId>json-simple</artifactId>
 			<version>1.1.1</version>
 		</dependency>
+		<dependency>
+			<groupId>io.jenkins.plugins</groupId>
+			<artifactId>commons-lang3-api</artifactId>
+		</dependency>
 		<!--  Pipeline Step dependencies -->
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/mathworks/ci/MatlabTestCase.java
+++ b/src/main/java/com/mathworks/ci/MatlabTestCase.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import com.mathworks.ci.TestResultsViewAction.TestStatus;
 

--- a/src/main/java/com/mathworks/ci/MatlabTestDiagnostics.java
+++ b/src/main/java/com/mathworks/ci/MatlabTestDiagnostics.java
@@ -7,7 +7,7 @@ package com.mathworks.ci;
  * 
  */
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 public class MatlabTestDiagnostics {
     private String event;

--- a/src/main/java/com/mathworks/ci/MatlabTestFile.java
+++ b/src/main/java/com/mathworks/ci/MatlabTestFile.java
@@ -12,7 +12,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import com.mathworks.ci.TestResultsViewAction.TestStatus;
 

--- a/src/main/java/com/mathworks/ci/actions/MatlabAction.java
+++ b/src/main/java/com/mathworks/ci/actions/MatlabAction.java
@@ -14,7 +14,7 @@ import com.mathworks.ci.utilities.MatlabCommandRunner;
 import hudson.FilePath;
 import hudson.model.Run;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/com/mathworks/ci/utilities/MatlabCommandRunner.java
+++ b/src/main/java/com/mathworks/ci/utilities/MatlabCommandRunner.java
@@ -10,7 +10,7 @@ import java.io.OutputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Map;
 import java.util.HashMap;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import hudson.FilePath;
 import hudson.EnvVars;


### PR DESCRIPTION
Migrate from deprecated/EOL Commons Lang 2 to Commons Lang 3.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

`RandomStringUtils.randomAlphanumeric` is used in five places to generate IDs. It has no clean
Java Platform equivalent, so this adds the `commons-lang3-api` library plugin (versionless — the
version comes from the Jenkins plugin BOM) and switches the imports to `org.apache.commons.lang3`.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.
The `ban-commons-lang-2` enforcer rule was left disabled because it needs parent POM
`6.2116.v7501b_67dc517` or newer; bumping the parent from `5.7` pulls in the Jakarta EE 9
migration, which is out of scope for this change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact
@parameter.
